### PR TITLE
chore: add development Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ test:
 	$(NPM) test
 
 docs:
-	$(NPM) run docs:build
+	$(PYTHON) -m mkdocs build --strict
 
 docs-serve:
-	$(NPM) run docs:serve
+	$(PYTHON) -m mkdocs serve
 
 mock-workspace:
 	$(NPM) run mock:workspace

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+.DEFAULT_GOAL := help
+
+NPM ?= npm
+PYTHON ?= python
+
+.PHONY: help setup install install-docs compile watch lint test docs docs-serve mock-workspace check ci all
+
+help:
+	@echo "Development targets:"
+	@echo "  make setup          Install extension and documentation dependencies"
+	@echo "  make install        Install extension dependencies from package-lock.json"
+	@echo "  make install-docs   Install documentation dependencies"
+	@echo "  make compile        Compile the TypeScript extension"
+	@echo "  make watch          Compile the TypeScript extension in watch mode"
+	@echo "  make lint           Run ESLint"
+	@echo "  make test           Run extension tests (npm pretest also compiles and lints)"
+	@echo "  make docs           Build documentation with strict MkDocs checks"
+	@echo "  make docs-serve     Serve documentation locally"
+	@echo "  make mock-workspace Create the mock HLS workspace fixture"
+	@echo "  make check          Run extension tests and documentation checks"
+
+setup: install install-docs
+
+install:
+	$(NPM) ci
+
+install-docs:
+	$(PYTHON) -m pip install -r requirements-docs.txt
+
+compile:
+	$(NPM) run compile
+
+watch:
+	$(NPM) run watch
+
+lint:
+	$(NPM) run lint
+
+test:
+	$(NPM) test
+
+docs:
+	$(NPM) run docs:build
+
+docs-serve:
+	$(NPM) run docs:serve
+
+mock-workspace:
+	$(NPM) run mock:workspace
+
+check: test docs
+
+ci all: check

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,9 @@ python -m pip install -r requirements-docs.txt
 The repository also includes Makefile shortcuts for the common development
 lifecycle. To install both extension and documentation dependencies:
 
+These shortcuts require GNU Make on `PATH`. On Windows, install it through your
+preferred development environment before using `make` commands.
+
 ```powershell
 make setup
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,6 +16,13 @@ Install documentation dependencies:
 python -m pip install -r requirements-docs.txt
 ```
 
+The repository also includes Makefile shortcuts for the common development
+lifecycle. To install both extension and documentation dependencies:
+
+```powershell
+make setup
+```
+
 ## Build The Extension
 
 Compile TypeScript:
@@ -28,6 +35,19 @@ Run lint:
 
 ```powershell
 npm run lint
+```
+
+Equivalent Makefile shortcuts are available:
+
+```powershell
+make compile
+make lint
+```
+
+Run the full extension and documentation check sequence:
+
+```powershell
+make check
 ```
 
 ## Run The Extension Locally
@@ -61,4 +81,11 @@ Serve the documentation locally while editing:
 
 ```powershell
 python -m mkdocs serve
+```
+
+Equivalent Makefile shortcuts are available:
+
+```powershell
+make docs
+make docs-serve
 ```


### PR DESCRIPTION
## Summary
- Add a GNU Makefile with common development lifecycle targets for setup, compile, lint, test, docs, and full checks.
- Document the Makefile shortcuts in the development guide.

## Verification
- `make help`
- `make check`