### PR TITLE
feat: add Vivado execution settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Planned Vivado work is tracked in GitHub issues and milestones. See the
 [Issue Dependency Plan](docs/issue-dependency-plan.md) for the full development
 path. The intended direction is:
 
-- Add `.xpr` activation, Vivado settings, and a reusable `vivadoRun` helper.
+- Build on `.xpr` activation and Vivado settings with a reusable `vivadoRun`
+  helper.
 - Introduce explicit Vivado project models instead of forcing Vivado concepts
   into the inherited HLS model.
 - Render a Vivado project tree for design sources, simulation sources,
@@ -60,9 +61,15 @@ This extension currently contributes these settings. See
 
 - `vitis-hls-ide.vitisPath`: path to the Vitis installation directory.
 - `vitis-hls-ide.hlsPath`: path to the Vitis HLS installation directory.
-
-Vivado path and execution settings are part of the planned Vivado foundation
-work.
+- `vscode-vivado.vivadoPath`: path to the Vivado installation directory.
+- `vscode-vivado.vivadoExecutablePath`: optional Vivado executable path or
+  command name.
+- `vscode-vivado.vivadoSettingsScript`: optional Vivado environment setup
+  script.
+- `vscode-vivado.projectSearchGlobs`: workspace globs for Vivado project
+  discovery.
+- `vscode-vivado.reportsDirectory`: default report artifact directory.
+- `vscode-vivado.preserveRunLogs`: whether Vivado task logs should be kept.
 
 ## Development
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ tree.
 ## Target Vivado Workflow
 
 The desired workflow is to open a VS Code workspace that contains one or more
-Vivado project files named `.xpr`.
+Vivado project files with the `.xpr` extension.
 
 The extension should then activate, discover Vivado projects, and show a Vivado-focused project tree with:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,11 +19,14 @@ The extension declares `ms-vscode.cpptools` as an extension dependency, so VS Co
 
 Open a VS Code workspace that contains one or more Vitis HLS project files named `hls.app`.
 
-The extension activates when VS Code finds an `hls.app` file in the workspace. After activation, the Vitis HLS IDE activity bar view contains the Projects tree.
+The extension activates when VS Code finds an `hls.app` file in the workspace.
+After activation, the Vitis HLS IDE activity bar view contains the Projects
+tree.
 
 ## Target Vivado Workflow
 
-The desired workflow is to open a VS Code workspace that contains one or more Vivado project files named `.xpr`.
+The desired workflow is to open a VS Code workspace that contains one or more
+Vivado project files named `.xpr`.
 
 The extension should then activate, discover Vivado projects, and show a Vivado-focused project tree with:
 
@@ -34,7 +37,10 @@ The extension should then activate, discover Vivado projects, and show a Vivado-
 - Runs for synthesis, implementation, and bitstream generation.
 - Reports and generated artifacts.
 
-Until `.xpr` activation and parsing are implemented, use the current Vitis HLS workflow for the behavior that exists today.
+The extension now activates for `.xpr` workspaces and contributes Vivado
+settings. Vivado project discovery and tree behavior are still under
+development, so use the current Vitis HLS workflow for the project tree and run
+commands that exist today.
 
 ## Configure Tool Paths Today
 
@@ -42,23 +48,20 @@ Open VS Code settings and configure:
 
 - `vitis-hls-ide.vitisPath`
 - `vitis-hls-ide.hlsPath`
+- `vscode-vivado.vivadoPath`
+- `vscode-vivado.vivadoExecutablePath`
+- `vscode-vivado.vivadoSettingsScript`
 
 The default Windows paths are:
 
 ```text
 C:\Xilinx\Vitis\2023.2
 C:\Xilinx\Vitis_HLS\2023.2
+C:\Xilinx\Vivado\2023.2
 ```
 
-## Desired Vivado Settings
-
-Vivado support should introduce settings for:
-
-- The Vivado installation path.
-- The preferred Vivado executable or `vivado` command path.
-- Default TCL batch mode behavior.
-- Optional workspace-specific project discovery globs.
-- Optional output locations for reports and generated task logs.
+The Vivado executable setting can be a full path or a command name such as
+`vivado` when the command is already available on `PATH`.
 
 ## C++ Include Path
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,6 +1,7 @@
 # Settings
 
-The current implementation contributes settings under `vitis-hls-ide`. Future Vivado support should add Vivado-specific settings rather than overloading the HLS settings.
+The extension keeps inherited Vitis HLS settings under `vitis-hls-ide` and
+adds Vivado-specific settings under `vscode-vivado`.
 
 ## Current HLS Settings
 
@@ -31,25 +32,46 @@ This path is used for:
 - C++ include path checks.
 - The GDB path used by the C simulation debug launch configuration.
 
-## To-Be Vivado Settings
+## Vivado Settings
 
-Vivado support should add settings similar to:
+## `vscode-vivado.vivadoPath`
 
-### `vscode-vivado.vivadoPath`
+Path to the Vivado installation directory. When
+`vscode-vivado.vivadoExecutablePath` is empty, the extension resolves the
+Vivado executable from this path.
 
-Path to the Vivado installation directory or the directory that contains the `vivado` executable.
-
-Example:
+Default:
 
 ```text
 C:\Xilinx\Vivado\2023.2
 ```
 
-### `vscode-vivado.projectSearchGlobs`
+## `vscode-vivado.vivadoExecutablePath`
+
+Optional full path to the Vivado executable, or a command name available on
+`PATH`.
+
+Default: empty string.
+
+When this setting is empty, the extension derives the executable from
+`vscode-vivado.vivadoPath`, using `bin\vivado.bat` on Windows and `bin/vivado`
+on Linux/macOS.
+
+## `vscode-vivado.vivadoSettingsScript`
+
+Optional path to a Vivado environment setup script, such as `settings64.bat` on
+Windows or `settings64.sh` on Linux.
+
+Default: empty string.
+
+Future Vivado task helpers can use this when Vivado is not already available on
+`PATH`.
+
+## `vscode-vivado.projectSearchGlobs`
 
 Workspace globs used to discover Vivado projects.
 
-Example:
+Default:
 
 ```json
 [
@@ -57,14 +79,22 @@ Example:
 ]
 ```
 
-### `vscode-vivado.tclBatchMode`
-
-Default behavior for commands that run Vivado TCL in batch mode.
-
-### `vscode-vivado.reportsDirectory`
+## `vscode-vivado.reportsDirectory`
 
 Optional workspace-relative directory for generated or copied report artifacts.
 
-### `vscode-vivado.preserveRunLogs`
+Default:
+
+```text
+reports
+```
+
+## `vscode-vivado.preserveRunLogs`
 
 Whether logs from synthesis, implementation, bitstream, and simulation tasks should be kept after task completion.
+
+Default:
+
+```text
+true
+```

--- a/package.json
+++ b/package.json
@@ -56,6 +56,41 @@
           "type": "string",
           "default": "C:\\Xilinx\\Vitis_HLS\\2023.2",
           "description": "Path to the Vitis HLS installation directory"
+        },
+        "vscode-vivado.vivadoPath": {
+          "type": "string",
+          "default": "C:\\Xilinx\\Vivado\\2023.2",
+          "description": "Path to the Vivado installation directory. When vscode-vivado.vivadoExecutablePath is empty, the extension resolves the Vivado executable from this path."
+        },
+        "vscode-vivado.vivadoExecutablePath": {
+          "type": "string",
+          "default": "",
+          "description": "Optional full path to the Vivado executable, or a command name available on PATH. Leave empty to resolve from vscode-vivado.vivadoPath."
+        },
+        "vscode-vivado.vivadoSettingsScript": {
+          "type": "string",
+          "default": "",
+          "description": "Optional path to a Vivado environment setup script such as settings64.bat or settings64.sh."
+        },
+        "vscode-vivado.projectSearchGlobs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "**/*.xpr"
+          ],
+          "description": "Workspace globs used to discover Vivado projects."
+        },
+        "vscode-vivado.reportsDirectory": {
+          "type": "string",
+          "default": "reports",
+          "description": "Workspace-relative directory used for Vivado report artifacts when commands need an explicit report output location."
+        },
+        "vscode-vivado.preserveRunLogs": {
+          "type": "boolean",
+          "default": true,
+          "description": "Keep Vivado task logs after synthesis, implementation, bitstream, and simulation tasks complete."
         }
       }
     },

--- a/src/test/utils/vivado-settings.test.ts
+++ b/src/test/utils/vivado-settings.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for Vivado configuration resolution.
+ * Covers #4 - Add Vivado path and execution settings.
+ */
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {
+    getVivadoExecutableName,
+    getVivadoSettings,
+    resolveVivadoBinPath,
+    resolveVivadoExecutablePath,
+    vivadoConfigSection,
+} from '../../utils/vivado-settings';
+
+function fakeConfiguration(values: Record<string, unknown>): Pick<vscode.WorkspaceConfiguration, 'get'> {
+    return {
+        get: <T>(key: string, defaultValue?: T): T => {
+            if (Object.prototype.hasOwnProperty.call(values, key)) {
+                return values[key] as T;
+            }
+            return defaultValue as T;
+        },
+    };
+}
+
+suite('Vivado settings contribution', () => {
+    test('package.json contributes the Vivado configuration section and keys', () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const pkg = require('../../../package.json');
+        const properties = pkg.contributes.configuration.properties;
+
+        assert.strictEqual(pkg.contributes.configuration.title, 'VS Code Vivado');
+        assert.ok(properties[`${vivadoConfigSection}.vivadoPath`]);
+        assert.ok(properties[`${vivadoConfigSection}.vivadoExecutablePath`]);
+        assert.ok(properties[`${vivadoConfigSection}.vivadoSettingsScript`]);
+        assert.ok(properties[`${vivadoConfigSection}.projectSearchGlobs`]);
+        assert.ok(properties[`${vivadoConfigSection}.reportsDirectory`]);
+        assert.ok(properties[`${vivadoConfigSection}.preserveRunLogs`]);
+    });
+});
+
+suite('Vivado settings resolution', () => {
+    test('uses Windows-first defaults from the package configuration contract', () => {
+        const settings = getVivadoSettings({
+            configuration: fakeConfiguration({}),
+            platform: 'win32',
+        });
+
+        assert.strictEqual(settings.vivadoPath, 'C:\\Xilinx\\Vivado\\2023.2');
+        assert.strictEqual(
+            settings.resolvedExecutablePath,
+            'C:\\Xilinx\\Vivado\\2023.2\\bin\\vivado.bat'
+        );
+        assert.deepStrictEqual(settings.projectSearchGlobs, ['**/*.xpr']);
+        assert.strictEqual(settings.reportsDirectory, 'reports');
+        assert.strictEqual(settings.preserveRunLogs, true);
+    });
+
+    test('uses explicit executable path before deriving from vivadoPath', () => {
+        const executable = 'D:\\Tools\\Vivado\\2024.2\\bin\\vivado.bat';
+        const settings = getVivadoSettings({
+            configuration: fakeConfiguration({
+                vivadoPath: 'C:\\Xilinx\\Vivado\\2023.2',
+                vivadoExecutablePath: ` ${executable} `,
+            }),
+            platform: 'win32',
+        });
+
+        assert.strictEqual(settings.resolvedExecutablePath, executable);
+        assert.deepStrictEqual(settings.pathEntries, [
+            'D:\\Tools\\Vivado\\2024.2\\bin',
+            'C:\\Xilinx\\Vivado\\2023.2\\bin',
+        ]);
+    });
+
+    test('derives a portable executable from an install path', () => {
+        assert.strictEqual(
+            resolveVivadoExecutablePath('', '/opt/Xilinx/Vivado/2024.2', 'linux'),
+            '/opt/Xilinx/Vivado/2024.2/bin/vivado'
+        );
+        assert.strictEqual(getVivadoExecutableName('darwin'), 'vivado');
+    });
+
+    test('does not append bin twice when vivadoPath already points at bin', () => {
+        assert.strictEqual(
+            resolveVivadoBinPath('C:\\Xilinx\\Vivado\\2023.2\\bin\\', 'win32'),
+            'C:\\Xilinx\\Vivado\\2023.2\\bin'
+        );
+    });
+
+    test('trims string settings and filters project discovery globs', () => {
+        const settings = getVivadoSettings({
+            configuration: fakeConfiguration({
+                vivadoPath: ' /tools/vivado ',
+                vivadoSettingsScript: ' /tools/vivado/settings64.sh ',
+                projectSearchGlobs: [' **/*.xpr ', '', '   ', '**/*.bd'],
+                reportsDirectory: ' vivado-reports ',
+                preserveRunLogs: false,
+            }),
+            platform: 'linux',
+        });
+
+        assert.strictEqual(settings.vivadoPath, '/tools/vivado');
+        assert.strictEqual(settings.vivadoSettingsScript, '/tools/vivado/settings64.sh');
+        assert.deepStrictEqual(settings.projectSearchGlobs, ['**/*.xpr', '**/*.bd']);
+        assert.strictEqual(settings.reportsDirectory, 'vivado-reports');
+        assert.strictEqual(settings.preserveRunLogs, false);
+    });
+
+    test('falls back to default discovery glob when configured globs are empty', () => {
+        const settings = getVivadoSettings({
+            configuration: fakeConfiguration({
+                projectSearchGlobs: ['', '   '],
+            }),
+            platform: 'linux',
+        });
+
+        assert.deepStrictEqual(settings.projectSearchGlobs, ['**/*.xpr']);
+    });
+
+    test('keeps command-name executable overrides on PATH', () => {
+        const settings = getVivadoSettings({
+            configuration: fakeConfiguration({
+                vivadoPath: '',
+                vivadoExecutablePath: 'vivado',
+            }),
+            platform: 'linux',
+        });
+
+        assert.strictEqual(settings.resolvedExecutablePath, 'vivado');
+        assert.deepStrictEqual(settings.pathEntries, []);
+        assert.strictEqual(path.posix.basename(settings.resolvedExecutablePath), 'vivado');
+    });
+});

--- a/src/test/utils/vivado-settings.test.ts
+++ b/src/test/utils/vivado-settings.test.ts
@@ -119,6 +119,17 @@ suite('Vivado settings resolution', () => {
         assert.deepStrictEqual(settings.projectSearchGlobs, ['**/*.xpr']);
     });
 
+    test('falls back to preserving run logs when the setting is not boolean', () => {
+        const settings = getVivadoSettings({
+            configuration: fakeConfiguration({
+                preserveRunLogs: 'false',
+            }),
+            platform: 'linux',
+        });
+
+        assert.strictEqual(settings.preserveRunLogs, true);
+    });
+
     test('keeps command-name executable overrides on PATH', () => {
         const settings = getVivadoSettings({
             configuration: fakeConfiguration({

--- a/src/utils/vivado-settings.ts
+++ b/src/utils/vivado-settings.ts
@@ -35,7 +35,7 @@ export function getVivadoSettings(options: VivadoSettingsOptions = {}): VivadoSe
         configuration.get<string[]>('projectSearchGlobs', defaultProjectSearchGlobs),
         defaultProjectSearchGlobs
     );
-    const preserveRunLogs = configuration.get<boolean>('preserveRunLogs', true) !== false;
+    const preserveRunLogs = normalizeBooleanSetting(configuration.get<unknown>('preserveRunLogs', true), true);
 
     return {
         vivadoPath,
@@ -119,6 +119,10 @@ function getPathApi(platform: NodeJS.Platform): path.PlatformPath {
 
 function normalizeStringSetting(value: string | undefined): string {
     return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeBooleanSetting(value: unknown, fallback: boolean): boolean {
+    return typeof value === 'boolean' ? value : fallback;
 }
 
 function normalizeStringArray(value: unknown, fallback: string[]): string[] {

--- a/src/utils/vivado-settings.ts
+++ b/src/utils/vivado-settings.ts
@@ -1,0 +1,135 @@
+import path from 'path';
+import * as vscode from 'vscode';
+
+export const vivadoConfigSection = 'vscode-vivado';
+
+const defaultVivadoPath = 'C:\\Xilinx\\Vivado\\2023.2';
+const defaultProjectSearchGlobs = ['**/*.xpr'];
+const defaultReportsDirectory = 'reports';
+
+export interface VivadoSettings {
+    vivadoPath: string;
+    vivadoExecutablePath: string;
+    vivadoSettingsScript: string;
+    projectSearchGlobs: string[];
+    reportsDirectory: string;
+    preserveRunLogs: boolean;
+    resolvedExecutablePath: string;
+    pathEntries: string[];
+}
+
+export interface VivadoSettingsOptions {
+    configuration?: Pick<vscode.WorkspaceConfiguration, 'get'>;
+    platform?: NodeJS.Platform;
+}
+
+export function getVivadoSettings(options: VivadoSettingsOptions = {}): VivadoSettings {
+    const configuration = options.configuration ?? vscode.workspace.getConfiguration(vivadoConfigSection);
+    const platform = options.platform ?? process.platform;
+
+    const vivadoPath = normalizeStringSetting(configuration.get<string>('vivadoPath', defaultVivadoPath));
+    const vivadoExecutablePath = normalizeStringSetting(configuration.get<string>('vivadoExecutablePath', ''));
+    const vivadoSettingsScript = normalizeStringSetting(configuration.get<string>('vivadoSettingsScript', ''));
+    const reportsDirectory = normalizeStringSetting(configuration.get<string>('reportsDirectory', defaultReportsDirectory)) || defaultReportsDirectory;
+    const projectSearchGlobs = normalizeStringArray(
+        configuration.get<string[]>('projectSearchGlobs', defaultProjectSearchGlobs),
+        defaultProjectSearchGlobs
+    );
+    const preserveRunLogs = configuration.get<boolean>('preserveRunLogs', true) !== false;
+
+    return {
+        vivadoPath,
+        vivadoExecutablePath,
+        vivadoSettingsScript,
+        projectSearchGlobs,
+        reportsDirectory,
+        preserveRunLogs,
+        resolvedExecutablePath: resolveVivadoExecutablePath(vivadoExecutablePath, vivadoPath, platform),
+        pathEntries: resolveVivadoPathEntries(vivadoExecutablePath, vivadoPath, platform),
+    };
+}
+
+export function resolveVivadoExecutablePath(
+    vivadoExecutablePath: string | undefined,
+    vivadoPath: string | undefined,
+    platform: NodeJS.Platform = process.platform,
+): string {
+    const explicitExecutable = normalizeStringSetting(vivadoExecutablePath);
+    if (explicitExecutable) {
+        return explicitExecutable;
+    }
+
+    const binPath = resolveVivadoBinPath(vivadoPath, platform);
+    if (binPath) {
+        return getPathApi(platform).join(binPath, getVivadoExecutableName(platform));
+    }
+
+    return getVivadoExecutableName(platform);
+}
+
+export function resolveVivadoBinPath(vivadoPath: string | undefined, platform: NodeJS.Platform = process.platform): string | undefined {
+    const normalizedVivadoPath = normalizeStringSetting(vivadoPath).replace(/[\\/]+$/, '');
+    if (!normalizedVivadoPath) {
+        return undefined;
+    }
+
+    const pathApi = getPathApi(platform);
+    if (pathApi.basename(normalizedVivadoPath).toLowerCase() === 'bin') {
+        return normalizedVivadoPath;
+    }
+
+    return pathApi.join(normalizedVivadoPath, 'bin');
+}
+
+export function getVivadoExecutableName(platform: NodeJS.Platform = process.platform): string {
+    return platform === 'win32' ? 'vivado.bat' : 'vivado';
+}
+
+function resolveVivadoPathEntries(
+    vivadoExecutablePath: string | undefined,
+    vivadoPath: string | undefined,
+    platform: NodeJS.Platform,
+): string[] {
+    const pathApi = getPathApi(platform);
+    const entries: string[] = [];
+    const explicitExecutable = normalizeStringSetting(vivadoExecutablePath);
+
+    if (explicitExecutable && looksLikePath(explicitExecutable, platform)) {
+        const executableDir = pathApi.dirname(explicitExecutable);
+        if (executableDir && executableDir !== '.') {
+            entries.push(executableDir);
+        }
+    }
+
+    const binPath = resolveVivadoBinPath(vivadoPath, platform);
+    if (binPath) {
+        entries.push(binPath);
+    }
+
+    return [...new Set(entries)];
+}
+
+function looksLikePath(value: string, platform: NodeJS.Platform): boolean {
+    return value.includes('/') || value.includes('\\') || getPathApi(platform).isAbsolute(value);
+}
+
+function getPathApi(platform: NodeJS.Platform): path.PlatformPath {
+    return platform === 'win32' ? path.win32 : path.posix;
+}
+
+function normalizeStringSetting(value: string | undefined): string {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeStringArray(value: unknown, fallback: string[]): string[] {
+    if (!Array.isArray(value)) {
+        return [...fallback];
+    }
+
+    const normalized = value
+        .filter((entry): entry is string => typeof entry === 'string')
+        .map(entry => entry.trim())
+        .filter(entry => entry.length > 0);
+
+    return normalized.length > 0 ? normalized : [...fallback];
+}


### PR DESCRIPTION
## Summary
- Add `vscode-vivado` settings for Vivado install path, executable override, environment setup script, project discovery globs, report directory, and log preservation.
- Add a typed Vivado settings resolver so later commands can consume normalized path/execution settings without duplicating path logic.
- Document the new settings in the README, getting started guide, and settings reference.

Closes #4

## Verification
- `npm run compile`
- `npm run lint`
- `npm test` (126 passing)
- `npm run docs:build`