### PR TITLE
feat: add Vivado batch runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Planned Vivado work is tracked in GitHub issues and milestones. See the
 [Issue Dependency Plan](docs/issue-dependency-plan.md) for the full development
 path. The intended direction is:
 
-- Add `.xpr` activation, Vivado settings, and a reusable `vivadoRun` helper.
+- Build on `.xpr` activation and Vivado settings with a reusable `vivadoRun`
+  helper.
 - Introduce explicit Vivado project models instead of forcing Vivado concepts
   into the inherited HLS model.
 - Render a Vivado project tree for design sources, simulation sources,
@@ -60,9 +61,15 @@ This extension currently contributes these settings. See
 
 - `vitis-hls-ide.vitisPath`: path to the Vitis installation directory.
 - `vitis-hls-ide.hlsPath`: path to the Vitis HLS installation directory.
-
-Vivado path and execution settings are part of the planned Vivado foundation
-work.
+- `vscode-vivado.vivadoPath`: path to the Vivado installation directory.
+- `vscode-vivado.vivadoExecutablePath`: optional Vivado executable path or
+  command name.
+- `vscode-vivado.vivadoSettingsScript`: optional Vivado environment setup
+  script.
+- `vscode-vivado.projectSearchGlobs`: workspace globs for Vivado project
+  discovery.
+- `vscode-vivado.reportsDirectory`: default report artifact directory.
+- `vscode-vivado.preserveRunLogs`: whether Vivado task logs should be kept.
 
 ## Development
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ tree.
 ## Target Vivado Workflow
 
 The desired workflow is to open a VS Code workspace that contains one or more
-Vivado project files named `.xpr`.
+Vivado project files with the `.xpr` extension.
 
 The extension should then activate, discover Vivado projects, and show a Vivado-focused project tree with:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,11 +19,14 @@ The extension declares `ms-vscode.cpptools` as an extension dependency, so VS Co
 
 Open a VS Code workspace that contains one or more Vitis HLS project files named `hls.app`.
 
-The extension activates when VS Code finds an `hls.app` file in the workspace. After activation, the Vitis HLS IDE activity bar view contains the Projects tree.
+The extension activates when VS Code finds an `hls.app` file in the workspace.
+After activation, the Vitis HLS IDE activity bar view contains the Projects
+tree.
 
 ## Target Vivado Workflow
 
-The desired workflow is to open a VS Code workspace that contains one or more Vivado project files named `.xpr`.
+The desired workflow is to open a VS Code workspace that contains one or more
+Vivado project files named `.xpr`.
 
 The extension should then activate, discover Vivado projects, and show a Vivado-focused project tree with:
 
@@ -34,7 +37,10 @@ The extension should then activate, discover Vivado projects, and show a Vivado-
 - Runs for synthesis, implementation, and bitstream generation.
 - Reports and generated artifacts.
 
-Until `.xpr` activation and parsing are implemented, use the current Vitis HLS workflow for the behavior that exists today.
+The extension now activates for `.xpr` workspaces and contributes Vivado
+settings. Vivado project discovery and tree behavior are still under
+development, so use the current Vitis HLS workflow for the project tree and run
+commands that exist today.
 
 ## Configure Tool Paths Today
 
@@ -42,23 +48,20 @@ Open VS Code settings and configure:
 
 - `vitis-hls-ide.vitisPath`
 - `vitis-hls-ide.hlsPath`
+- `vscode-vivado.vivadoPath`
+- `vscode-vivado.vivadoExecutablePath`
+- `vscode-vivado.vivadoSettingsScript`
 
 The default Windows paths are:
 
 ```text
 C:\Xilinx\Vitis\2023.2
 C:\Xilinx\Vitis_HLS\2023.2
+C:\Xilinx\Vivado\2023.2
 ```
 
-## Desired Vivado Settings
-
-Vivado support should introduce settings for:
-
-- The Vivado installation path.
-- The preferred Vivado executable or `vivado` command path.
-- Default TCL batch mode behavior.
-- Optional workspace-specific project discovery globs.
-- Optional output locations for reports and generated task logs.
+The Vivado executable setting can be a full path or a command name such as
+`vivado` when the command is already available on `PATH`.
 
 ## C++ Include Path
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,6 +1,7 @@
 # Settings
 
-The current implementation contributes settings under `vitis-hls-ide`. Future Vivado support should add Vivado-specific settings rather than overloading the HLS settings.
+The extension keeps inherited Vitis HLS settings under `vitis-hls-ide` and
+adds Vivado-specific settings under `vscode-vivado`.
 
 ## Current HLS Settings
 
@@ -31,25 +32,46 @@ This path is used for:
 - C++ include path checks.
 - The GDB path used by the C simulation debug launch configuration.
 
-## To-Be Vivado Settings
+## Vivado Settings
 
-Vivado support should add settings similar to:
+## `vscode-vivado.vivadoPath`
 
-### `vscode-vivado.vivadoPath`
+Path to the Vivado installation directory. When
+`vscode-vivado.vivadoExecutablePath` is empty, the extension resolves the
+Vivado executable from this path.
 
-Path to the Vivado installation directory or the directory that contains the `vivado` executable.
-
-Example:
+Default:
 
 ```text
 C:\Xilinx\Vivado\2023.2
 ```
 
-### `vscode-vivado.projectSearchGlobs`
+## `vscode-vivado.vivadoExecutablePath`
+
+Optional full path to the Vivado executable, or a command name available on
+`PATH`.
+
+Default: empty string.
+
+When this setting is empty, the extension derives the executable from
+`vscode-vivado.vivadoPath`, using `bin\vivado.bat` on Windows and `bin/vivado`
+on Linux/macOS.
+
+## `vscode-vivado.vivadoSettingsScript`
+
+Optional path to a Vivado environment setup script, such as `settings64.bat` on
+Windows or `settings64.sh` on Linux.
+
+Default: empty string.
+
+Future Vivado task helpers can use this when Vivado is not already available on
+`PATH`.
+
+## `vscode-vivado.projectSearchGlobs`
 
 Workspace globs used to discover Vivado projects.
 
-Example:
+Default:
 
 ```json
 [
@@ -57,14 +79,22 @@ Example:
 ]
 ```
 
-### `vscode-vivado.tclBatchMode`
-
-Default behavior for commands that run Vivado TCL in batch mode.
-
-### `vscode-vivado.reportsDirectory`
+## `vscode-vivado.reportsDirectory`
 
 Optional workspace-relative directory for generated or copied report artifacts.
 
-### `vscode-vivado.preserveRunLogs`
+Default:
+
+```text
+reports
+```
+
+## `vscode-vivado.preserveRunLogs`
 
 Whether logs from synthesis, implementation, bitstream, and simulation tasks should be kept after task completion.
+
+Default:
+
+```text
+true
+```

--- a/package.json
+++ b/package.json
@@ -56,6 +56,41 @@
           "type": "string",
           "default": "C:\\Xilinx\\Vitis_HLS\\2023.2",
           "description": "Path to the Vitis HLS installation directory"
+        },
+        "vscode-vivado.vivadoPath": {
+          "type": "string",
+          "default": "C:\\Xilinx\\Vivado\\2023.2",
+          "description": "Path to the Vivado installation directory. When vscode-vivado.vivadoExecutablePath is empty, the extension resolves the Vivado executable from this path."
+        },
+        "vscode-vivado.vivadoExecutablePath": {
+          "type": "string",
+          "default": "",
+          "description": "Optional full path to the Vivado executable, or a command name available on PATH. Leave empty to resolve from vscode-vivado.vivadoPath."
+        },
+        "vscode-vivado.vivadoSettingsScript": {
+          "type": "string",
+          "default": "",
+          "description": "Optional path to a Vivado environment setup script such as settings64.bat or settings64.sh."
+        },
+        "vscode-vivado.projectSearchGlobs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "**/*.xpr"
+          ],
+          "description": "Workspace globs used to discover Vivado projects."
+        },
+        "vscode-vivado.reportsDirectory": {
+          "type": "string",
+          "default": "reports",
+          "description": "Workspace-relative directory used for Vivado report artifacts when commands need an explicit report output location."
+        },
+        "vscode-vivado.preserveRunLogs": {
+          "type": "boolean",
+          "default": true,
+          "description": "Keep Vivado task logs after synthesis, implementation, bitstream, and simulation tasks complete."
         }
       }
     },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
 
 export const taskSource = 'Vitis HLS IDE';
+export const vivadoTaskSource = 'VS Code Vivado';

--- a/src/test/utils/vivado-run.test.ts
+++ b/src/test/utils/vivado-run.test.ts
@@ -81,7 +81,7 @@ suite('vivadoRun command construction', () => {
 
         assert.strictEqual(
             command,
-            'cmd.exe /d /c """C:\\Xilinx\\Vivado\\2023.2\\bin\\vivado.bat"" -mode batch -source ""C:\\work\\run synth.tcl"""'
+            'cmd.exe /d /c ""C:\\Xilinx\\Vivado\\2023.2\\bin\\vivado.bat" -mode batch -source "C:\\work\\run synth.tcl""'
         );
     });
 
@@ -96,7 +96,7 @@ suite('vivadoRun command construction', () => {
 
         assert.strictEqual(
             command,
-            'cmd.exe /d /c "call ""C:\\Xilinx\\Vivado\\2023.2\\settings64.bat"" && ""C:\\Xilinx\\Vivado\\2023.2\\bin\\vivado.bat"" -mode batch -source ""C:\\work\\run synth.tcl"""'
+            'cmd.exe /d /c "call "C:\\Xilinx\\Vivado\\2023.2\\settings64.bat" && "C:\\Xilinx\\Vivado\\2023.2\\bin\\vivado.bat" -mode batch -source "C:\\work\\run synth.tcl""'
         );
     });
 
@@ -276,7 +276,12 @@ suite('vivadoRun task execution', () => {
         }
 
         const exec = getTask()!.execution as vscode.ShellExecution;
+        const env = (exec.options as any)?.env as Record<string, string | undefined> | undefined;
+        const pathKey = env ? Object.keys(env).find(key => key.toLowerCase() === 'path') : undefined;
+        const pathValue = pathKey ? env?.[pathKey] ?? '' : '';
+
         assert.strictEqual((exec.options as any)?.cwd, startPath.fsPath);
-        assert.ok(((exec.options as any)?.env?.PATH ?? '').includes('C:\\Xilinx\\Vivado\\2023.2\\bin'));
+        assert.ok(pathKey);
+        assert.ok(pathValue.includes('C:\\Xilinx\\Vivado\\2023.2\\bin'));
     });
 });

--- a/src/test/utils/vivado-run.test.ts
+++ b/src/test/utils/vivado-run.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for the vivadoRun helper.
+ * Covers #5 - Implement vivadoRun helper for TCL-backed batch tasks.
+ */
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { vivadoTaskSource } from '../../constants';
+import { VivadoSettings } from '../../utils/vivado-settings';
+import {
+    buildVivadoCommandLine,
+    buildVivadoEnvironment,
+    vivadoRun,
+    vivadoRunScript,
+} from '../../utils/vivado-run';
+
+function makeSettings(overrides: Partial<VivadoSettings> = {}): VivadoSettings {
+    return {
+        vivadoPath: 'C:\\Xilinx\\Vivado\\2023.2',
+        vivadoExecutablePath: '',
+        vivadoSettingsScript: '',
+        projectSearchGlobs: ['**/*.xpr'],
+        reportsDirectory: 'reports',
+        preserveRunLogs: true,
+        resolvedExecutablePath: 'C:\\Xilinx\\Vivado\\2023.2\\bin\\vivado.bat',
+        pathEntries: ['C:\\Xilinx\\Vivado\\2023.2\\bin'],
+        ...overrides,
+    };
+}
+
+function stubVivadoRunTasks(exitCode: number | undefined): {
+    cleanup: () => void;
+    getTask: () => vscode.Task | undefined;
+} {
+    let capturedTask: vscode.Task | undefined;
+
+    const origExecuteTask = Object.getOwnPropertyDescriptor(vscode.tasks, 'executeTask');
+    Object.defineProperty(vscode.tasks, 'executeTask', {
+        value: (task: vscode.Task) => {
+            capturedTask = task;
+            return Promise.resolve({ task } as unknown as vscode.TaskExecution);
+        },
+        configurable: true,
+        writable: true,
+    });
+
+    const origEndTask = Object.getOwnPropertyDescriptor(vscode.tasks, 'onDidEndTaskProcess');
+    Object.defineProperty(vscode.tasks, 'onDidEndTaskProcess', {
+        value: (handler: (e: { execution: vscode.TaskExecution; exitCode: number | undefined }) => void) => {
+            setImmediate(() => {
+                if (capturedTask) {
+                    handler({
+                        execution: { task: capturedTask } as unknown as vscode.TaskExecution,
+                        exitCode,
+                    });
+                }
+            });
+            return { dispose: () => { /* no-op */ } };
+        },
+        configurable: true,
+        writable: true,
+    });
+
+    return {
+        cleanup: () => {
+            if (origExecuteTask) { Object.defineProperty(vscode.tasks, 'executeTask', origExecuteTask); }
+            if (origEndTask) { Object.defineProperty(vscode.tasks, 'onDidEndTaskProcess', origEndTask); }
+        },
+        getTask: () => capturedTask,
+    };
+}
+
+suite('vivadoRun command construction', () => {
+    test('builds a direct Vivado batch command for Windows', () => {
+        const command = buildVivadoCommandLine(
+            makeSettings(),
+            'C:\\work\\run synth.tcl',
+            'win32',
+        );
+
+        assert.strictEqual(
+            command,
+            'cmd.exe /d /c """C:\\Xilinx\\Vivado\\2023.2\\bin\\vivado.bat"" -mode batch -source ""C:\\work\\run synth.tcl"""'
+        );
+    });
+
+    test('builds a source-settings command for Windows batch shells', () => {
+        const command = buildVivadoCommandLine(
+            makeSettings({
+                vivadoSettingsScript: 'C:\\Xilinx\\Vivado\\2023.2\\settings64.bat',
+            }),
+            'C:\\work\\run synth.tcl',
+            'win32',
+        );
+
+        assert.strictEqual(
+            command,
+            'cmd.exe /d /c "call ""C:\\Xilinx\\Vivado\\2023.2\\settings64.bat"" && ""C:\\Xilinx\\Vivado\\2023.2\\bin\\vivado.bat"" -mode batch -source ""C:\\work\\run synth.tcl"""'
+        );
+    });
+
+    test('builds a source-settings command for POSIX shells', () => {
+        const command = buildVivadoCommandLine(
+            makeSettings({
+                vivadoSettingsScript: '/opt/Xilinx/Vivado/2024.2/settings64.sh',
+                resolvedExecutablePath: '/opt/Xilinx/Vivado/2024.2/bin/vivado',
+                pathEntries: ['/opt/Xilinx/Vivado/2024.2/bin'],
+            }),
+            "/tmp/run user's script.tcl",
+            'linux',
+        );
+
+        assert.strictEqual(
+            command,
+            ". '/opt/Xilinx/Vivado/2024.2/settings64.sh' && '/opt/Xilinx/Vivado/2024.2/bin/vivado' -mode batch -source '/tmp/run user'\\''s script.tcl'"
+        );
+    });
+
+    test('prepends configured Vivado path entries to PATH', () => {
+        const env = buildVivadoEnvironment(
+            makeSettings({
+                pathEntries: ['/tools/vivado/bin'],
+            }),
+            { PATH: '/usr/bin' },
+            'linux',
+        );
+
+        assert.strictEqual(env.PATH, '/tools/vivado/bin:/usr/bin');
+    });
+});
+
+suite('vivadoRun task execution', () => {
+    test('writes generated TCL to a temp file before executing the task', async () => {
+        const expectedTcl = 'open_project project.xpr\nexit';
+        const { cleanup, getTask } = stubVivadoRunTasks(0);
+
+        let result: number | undefined;
+        let tclFilePath: string | undefined;
+        let tclFileContent: string | undefined;
+
+        try {
+            result = await vivadoRun(
+                vscode.Uri.file('/workspace'),
+                expectedTcl,
+                'vivado-tcl-content-check',
+                {
+                    settings: makeSettings({
+                        resolvedExecutablePath: '/opt/Xilinx/Vivado/2024.2/bin/vivado',
+                        pathEntries: ['/opt/Xilinx/Vivado/2024.2/bin'],
+                    }),
+                    platform: 'linux',
+                    preserveTclFile: true,
+                },
+            );
+        } finally {
+            cleanup();
+        }
+
+        const capturedTask = getTask();
+        assert.ok(capturedTask, 'executeTask must have been called');
+        const commandLine = (capturedTask!.execution as vscode.ShellExecution).commandLine ?? '';
+        const match = commandLine.match(/-source '([^']+)'/);
+        assert.ok(match, 'Vivado command line must include a quoted -source path');
+        tclFilePath = match![1];
+        tclFileContent = fs.readFileSync(tclFilePath, 'utf8');
+        fs.unlinkSync(tclFilePath);
+
+        assert.strictEqual(result, 0);
+        assert.ok(path.basename(tclFilePath).startsWith('vscode-vivado-tcl-'));
+        assert.strictEqual(tclFileContent, expectedTcl);
+    });
+
+    test('runs a checked-in TCL script without generating a new script', async () => {
+        const scriptPath = vscode.Uri.file('/workspace/scripts/run_synth.tcl');
+        const { cleanup, getTask } = stubVivadoRunTasks(0);
+
+        try {
+            await vivadoRunScript(
+                vscode.Uri.file('/workspace'),
+                scriptPath,
+                'checked-in-script',
+                {
+                    settings: makeSettings(),
+                    platform: 'win32',
+                },
+            );
+        } finally {
+            cleanup();
+        }
+
+        const commandLine = (getTask()!.execution as vscode.ShellExecution).commandLine ?? '';
+        assert.ok(commandLine.includes('-source'));
+        assert.ok(commandLine.includes(scriptPath.fsPath));
+    });
+
+    test('task metadata uses the Vivado task source and provided task name', async () => {
+        const { cleanup, getTask } = stubVivadoRunTasks(0);
+
+        try {
+            await vivadoRun(
+                vscode.Uri.file('/workspace'),
+                'exit',
+                'custom-vivado-task',
+                {
+                    settings: makeSettings(),
+                    platform: 'win32',
+                },
+            );
+        } finally {
+            cleanup();
+        }
+
+        assert.strictEqual(getTask()?.name, 'custom-vivado-task');
+        assert.strictEqual(getTask()?.source, vivadoTaskSource);
+    });
+
+    test('resolves with the task exit code', async () => {
+        const { cleanup } = stubVivadoRunTasks(17);
+
+        let result: number | undefined;
+        try {
+            result = await vivadoRun(
+                vscode.Uri.file('/workspace'),
+                'exit',
+                'exit-code-check',
+                {
+                    settings: makeSettings(),
+                    platform: 'win32',
+                },
+            );
+        } finally {
+            cleanup();
+        }
+
+        assert.strictEqual(result, 17);
+    });
+
+    test('resolves with undefined when the task is cancelled', async () => {
+        const { cleanup } = stubVivadoRunTasks(undefined);
+
+        let result: number | undefined = 999;
+        try {
+            result = await vivadoRun(
+                vscode.Uri.file('/workspace'),
+                'exit',
+                'cancel-check',
+                {
+                    settings: makeSettings(),
+                    platform: 'win32',
+                },
+            );
+        } finally {
+            cleanup();
+        }
+
+        assert.strictEqual(result, undefined);
+    });
+
+    test('sets the working directory and Vivado PATH on the shell execution', async () => {
+        const startPath = vscode.Uri.file('/workspace/project');
+        const { cleanup, getTask } = stubVivadoRunTasks(0);
+
+        try {
+            await vivadoRun(
+                startPath,
+                'exit',
+                'cwd-path-check',
+                {
+                    settings: makeSettings(),
+                    platform: 'win32',
+                },
+            );
+        } finally {
+            cleanup();
+        }
+
+        const exec = getTask()!.execution as vscode.ShellExecution;
+        assert.strictEqual((exec.options as any)?.cwd, startPath.fsPath);
+        assert.ok(((exec.options as any)?.env?.PATH ?? '').includes('C:\\Xilinx\\Vivado\\2023.2\\bin'));
+    });
+});

--- a/src/test/utils/vivado-settings.test.ts
+++ b/src/test/utils/vivado-settings.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for Vivado configuration resolution.
+ * Covers #4 - Add Vivado path and execution settings.
+ */
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {
+    getVivadoExecutableName,
+    getVivadoSettings,
+    resolveVivadoBinPath,
+    resolveVivadoExecutablePath,
+    vivadoConfigSection,
+} from '../../utils/vivado-settings';
+
+function fakeConfiguration(values: Record<string, unknown>): Pick<vscode.WorkspaceConfiguration, 'get'> {
+    return {
+        get: <T>(key: string, defaultValue?: T): T => {
+            if (Object.prototype.hasOwnProperty.call(values, key)) {
+                return values[key] as T;
+            }
+            return defaultValue as T;
+        },
+    };
+}
+
+suite('Vivado settings contribution', () => {
+    test('package.json contributes the Vivado configuration section and keys', () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const pkg = require('../../../package.json');
+        const properties = pkg.contributes.configuration.properties;
+
+        assert.strictEqual(pkg.contributes.configuration.title, 'VS Code Vivado');
+        assert.ok(properties[`${vivadoConfigSection}.vivadoPath`]);
+        assert.ok(properties[`${vivadoConfigSection}.vivadoExecutablePath`]);
+        assert.ok(properties[`${vivadoConfigSection}.vivadoSettingsScript`]);
+        assert.ok(properties[`${vivadoConfigSection}.projectSearchGlobs`]);
+        assert.ok(properties[`${vivadoConfigSection}.reportsDirectory`]);
+        assert.ok(properties[`${vivadoConfigSection}.preserveRunLogs`]);
+    });
+});
+
+suite('Vivado settings resolution', () => {
+    test('uses Windows-first defaults from the package configuration contract', () => {
+        const settings = getVivadoSettings({
+            configuration: fakeConfiguration({}),
+            platform: 'win32',
+        });
+
+        assert.strictEqual(settings.vivadoPath, 'C:\\Xilinx\\Vivado\\2023.2');
+        assert.strictEqual(
+            settings.resolvedExecutablePath,
+            'C:\\Xilinx\\Vivado\\2023.2\\bin\\vivado.bat'
+        );
+        assert.deepStrictEqual(settings.projectSearchGlobs, ['**/*.xpr']);
+        assert.strictEqual(settings.reportsDirectory, 'reports');
+        assert.strictEqual(settings.preserveRunLogs, true);
+    });
+
+    test('uses explicit executable path before deriving from vivadoPath', () => {
+        const executable = 'D:\\Tools\\Vivado\\2024.2\\bin\\vivado.bat';
+        const settings = getVivadoSettings({
+            configuration: fakeConfiguration({
+                vivadoPath: 'C:\\Xilinx\\Vivado\\2023.2',
+                vivadoExecutablePath: ` ${executable} `,
+            }),
+            platform: 'win32',
+        });
+
+        assert.strictEqual(settings.resolvedExecutablePath, executable);
+        assert.deepStrictEqual(settings.pathEntries, [
+            'D:\\Tools\\Vivado\\2024.2\\bin',
+            'C:\\Xilinx\\Vivado\\2023.2\\bin',
+        ]);
+    });
+
+    test('derives a portable executable from an install path', () => {
+        assert.strictEqual(
+            resolveVivadoExecutablePath('', '/opt/Xilinx/Vivado/2024.2', 'linux'),
+            '/opt/Xilinx/Vivado/2024.2/bin/vivado'
+        );
+        assert.strictEqual(getVivadoExecutableName('darwin'), 'vivado');
+    });
+
+    test('does not append bin twice when vivadoPath already points at bin', () => {
+        assert.strictEqual(
+            resolveVivadoBinPath('C:\\Xilinx\\Vivado\\2023.2\\bin\\', 'win32'),
+            'C:\\Xilinx\\Vivado\\2023.2\\bin'
+        );
+    });
+
+    test('trims string settings and filters project discovery globs', () => {
+        const settings = getVivadoSettings({
+            configuration: fakeConfiguration({
+                vivadoPath: ' /tools/vivado ',
+                vivadoSettingsScript: ' /tools/vivado/settings64.sh ',
+                projectSearchGlobs: [' **/*.xpr ', '', '   ', '**/*.bd'],
+                reportsDirectory: ' vivado-reports ',
+                preserveRunLogs: false,
+            }),
+            platform: 'linux',
+        });
+
+        assert.strictEqual(settings.vivadoPath, '/tools/vivado');
+        assert.strictEqual(settings.vivadoSettingsScript, '/tools/vivado/settings64.sh');
+        assert.deepStrictEqual(settings.projectSearchGlobs, ['**/*.xpr', '**/*.bd']);
+        assert.strictEqual(settings.reportsDirectory, 'vivado-reports');
+        assert.strictEqual(settings.preserveRunLogs, false);
+    });
+
+    test('falls back to default discovery glob when configured globs are empty', () => {
+        const settings = getVivadoSettings({
+            configuration: fakeConfiguration({
+                projectSearchGlobs: ['', '   '],
+            }),
+            platform: 'linux',
+        });
+
+        assert.deepStrictEqual(settings.projectSearchGlobs, ['**/*.xpr']);
+    });
+
+    test('keeps command-name executable overrides on PATH', () => {
+        const settings = getVivadoSettings({
+            configuration: fakeConfiguration({
+                vivadoPath: '',
+                vivadoExecutablePath: 'vivado',
+            }),
+            platform: 'linux',
+        });
+
+        assert.strictEqual(settings.resolvedExecutablePath, 'vivado');
+        assert.deepStrictEqual(settings.pathEntries, []);
+        assert.strictEqual(path.posix.basename(settings.resolvedExecutablePath), 'vivado');
+    });
+});

--- a/src/test/utils/vivado-settings.test.ts
+++ b/src/test/utils/vivado-settings.test.ts
@@ -119,6 +119,17 @@ suite('Vivado settings resolution', () => {
         assert.deepStrictEqual(settings.projectSearchGlobs, ['**/*.xpr']);
     });
 
+    test('falls back to preserving run logs when the setting is not boolean', () => {
+        const settings = getVivadoSettings({
+            configuration: fakeConfiguration({
+                preserveRunLogs: 'false',
+            }),
+            platform: 'linux',
+        });
+
+        assert.strictEqual(settings.preserveRunLogs, true);
+    });
+
     test('keeps command-name executable overrides on PATH', () => {
         const settings = getVivadoSettings({
             configuration: fakeConfiguration({

--- a/src/utils/vivado-run.ts
+++ b/src/utils/vivado-run.ts
@@ -1,0 +1,188 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as vscode from 'vscode';
+import { vivadoTaskSource } from '../constants';
+import { getVivadoSettings, VivadoSettings } from './vivado-settings';
+
+export interface VivadoRunOptions {
+    settings?: VivadoSettings;
+    presentationOptions?: vscode.TaskPresentationOptions;
+    problemMatchers?: string[];
+    preserveTclFile?: boolean;
+    tclDirectory?: vscode.Uri;
+    platform?: NodeJS.Platform;
+}
+
+export async function vivadoRun(
+    startPath: vscode.Uri,
+    tcl: string,
+    taskName: string,
+    options: VivadoRunOptions = {},
+): Promise<number | undefined> {
+    const tclFilePath = writeTclFile(tcl, options.tclDirectory);
+
+    return vivadoRunScript(
+        startPath,
+        vscode.Uri.file(tclFilePath),
+        taskName,
+        {
+            ...options,
+            preserveTclFile: options.preserveTclFile ?? false,
+        },
+        options.preserveTclFile ? undefined : tclFilePath,
+    );
+}
+
+export async function vivadoRunScript(
+    startPath: vscode.Uri,
+    tclFile: vscode.Uri,
+    taskName: string,
+    options: VivadoRunOptions = {},
+    cleanupTclFilePath?: string,
+): Promise<number | undefined> {
+    const platform = options.platform ?? process.platform;
+    const settings = options.settings ?? getVivadoSettings({ platform });
+    const task = buildVivadoTask(startPath, tclFile, taskName, settings, options, platform);
+
+    let disposable: vscode.Disposable | undefined;
+    const exitCode = new Promise<number | undefined>((resolve) => {
+        disposable = vscode.tasks.onDidEndTaskProcess(e => {
+            if (e.execution.task === task) {
+                disposable?.dispose();
+                cleanupTclFile(cleanupTclFilePath);
+                resolve(e.exitCode);
+            }
+        });
+    });
+
+    try {
+        await vscode.tasks.executeTask(task);
+    } catch (error) {
+        disposable?.dispose();
+        cleanupTclFile(cleanupTclFilePath);
+        throw error;
+    }
+
+    return exitCode;
+}
+
+export function buildVivadoCommandLine(settings: VivadoSettings, tclFilePath: string, platform: NodeJS.Platform = process.platform): string {
+    const vivadoCommand = [
+        quoteShellArgument(settings.resolvedExecutablePath, platform),
+        '-mode',
+        'batch',
+        '-source',
+        quoteShellArgument(tclFilePath, platform),
+    ].join(' ');
+
+    if (platform === 'win32') {
+        const command = settings.vivadoSettingsScript
+            ? `call ${quoteShellArgument(settings.vivadoSettingsScript, platform)} && ${vivadoCommand}`
+            : vivadoCommand;
+
+        return `cmd.exe /d /c ${quoteWindowsCommand(command)}`;
+    }
+
+    if (!settings.vivadoSettingsScript) {
+        return vivadoCommand;
+    }
+
+    const settingsCommand = `. ${quoteShellArgument(settings.vivadoSettingsScript, platform)}`;
+
+    return `${settingsCommand} && ${vivadoCommand}`;
+}
+
+export function buildVivadoEnvironment(
+    settings: VivadoSettings,
+    baseEnvironment: NodeJS.ProcessEnv = process.env,
+    platform: NodeJS.Platform = process.platform,
+): { [key: string]: string } {
+    const env: { [key: string]: string } = {};
+    for (const [key, value] of Object.entries(baseEnvironment)) {
+        if (value !== undefined) {
+            env[key] = value;
+        }
+    }
+
+    if (settings.pathEntries.length === 0) {
+        return env;
+    }
+
+    const pathKey = Object.keys(env).find(key => key.toLowerCase() === 'path') ?? 'PATH';
+    const delimiter = platform === 'win32' ? ';' : ':';
+    const currentPath = env[pathKey];
+    env[pathKey] = [
+        ...settings.pathEntries,
+        ...(currentPath ? [currentPath] : []),
+    ].join(delimiter);
+
+    return env;
+}
+
+function buildVivadoTask(
+    startPath: vscode.Uri,
+    tclFile: vscode.Uri,
+    taskName: string,
+    settings: VivadoSettings,
+    options: VivadoRunOptions,
+    platform: NodeJS.Platform,
+): vscode.Task {
+    const shellExecution = new vscode.ShellExecution(
+        buildVivadoCommandLine(settings, tclFile.fsPath, platform),
+        {
+            cwd: startPath.fsPath,
+            env: buildVivadoEnvironment(settings, process.env, platform),
+        },
+    );
+
+    const task = new vscode.Task(
+        { type: 'shell' },
+        vscode.TaskScope.Workspace,
+        taskName,
+        vivadoTaskSource,
+        shellExecution,
+        options.problemMatchers,
+    );
+
+    if (options.presentationOptions !== undefined) {
+        task.presentationOptions = options.presentationOptions;
+    }
+
+    return task;
+}
+
+function writeTclFile(tcl: string, directory?: vscode.Uri): string {
+    const targetDirectory = directory?.fsPath ?? os.tmpdir();
+    fs.mkdirSync(targetDirectory, { recursive: true });
+
+    const fileName = `vscode-vivado-tcl-${Date.now()}.tcl`;
+    const tclFilePath = path.join(targetDirectory, fileName);
+    fs.writeFileSync(tclFilePath, tcl);
+
+    return tclFilePath;
+}
+
+function cleanupTclFile(tclFilePath: string | undefined): void {
+    if (!tclFilePath) {
+        return;
+    }
+
+    fs.unlink(tclFilePath, err => {
+        if (err) {
+            console.error(`Error deleting file ${tclFilePath}:`, err);
+        }
+    });
+}
+
+function quoteShellArgument(value: string, platform: NodeJS.Platform): string {
+    if (platform === 'win32') {
+        return `"${value.replace(/"/g, '""')}"`;
+    }
+
+    return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function quoteWindowsCommand(value: string): string {
+    return `"${value.replace(/"/g, '""')}"`;
+}

--- a/src/utils/vivado-run.ts
+++ b/src/utils/vivado-run.ts
@@ -184,5 +184,5 @@ function quoteShellArgument(value: string, platform: NodeJS.Platform): string {
 }
 
 function quoteWindowsCommand(value: string): string {
-    return `"${value.replace(/"/g, '""')}"`;
+    return `"${value}"`;
 }

--- a/src/utils/vivado-settings.ts
+++ b/src/utils/vivado-settings.ts
@@ -35,7 +35,7 @@ export function getVivadoSettings(options: VivadoSettingsOptions = {}): VivadoSe
         configuration.get<string[]>('projectSearchGlobs', defaultProjectSearchGlobs),
         defaultProjectSearchGlobs
     );
-    const preserveRunLogs = configuration.get<boolean>('preserveRunLogs', true) !== false;
+    const preserveRunLogs = normalizeBooleanSetting(configuration.get<unknown>('preserveRunLogs', true), true);
 
     return {
         vivadoPath,
@@ -119,6 +119,10 @@ function getPathApi(platform: NodeJS.Platform): path.PlatformPath {
 
 function normalizeStringSetting(value: string | undefined): string {
     return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeBooleanSetting(value: unknown, fallback: boolean): boolean {
+    return typeof value === 'boolean' ? value : fallback;
 }
 
 function normalizeStringArray(value: unknown, fallback: string[]): string[] {

--- a/src/utils/vivado-settings.ts
+++ b/src/utils/vivado-settings.ts
@@ -1,0 +1,135 @@
+import path from 'path';
+import * as vscode from 'vscode';
+
+export const vivadoConfigSection = 'vscode-vivado';
+
+const defaultVivadoPath = 'C:\\Xilinx\\Vivado\\2023.2';
+const defaultProjectSearchGlobs = ['**/*.xpr'];
+const defaultReportsDirectory = 'reports';
+
+export interface VivadoSettings {
+    vivadoPath: string;
+    vivadoExecutablePath: string;
+    vivadoSettingsScript: string;
+    projectSearchGlobs: string[];
+    reportsDirectory: string;
+    preserveRunLogs: boolean;
+    resolvedExecutablePath: string;
+    pathEntries: string[];
+}
+
+export interface VivadoSettingsOptions {
+    configuration?: Pick<vscode.WorkspaceConfiguration, 'get'>;
+    platform?: NodeJS.Platform;
+}
+
+export function getVivadoSettings(options: VivadoSettingsOptions = {}): VivadoSettings {
+    const configuration = options.configuration ?? vscode.workspace.getConfiguration(vivadoConfigSection);
+    const platform = options.platform ?? process.platform;
+
+    const vivadoPath = normalizeStringSetting(configuration.get<string>('vivadoPath', defaultVivadoPath));
+    const vivadoExecutablePath = normalizeStringSetting(configuration.get<string>('vivadoExecutablePath', ''));
+    const vivadoSettingsScript = normalizeStringSetting(configuration.get<string>('vivadoSettingsScript', ''));
+    const reportsDirectory = normalizeStringSetting(configuration.get<string>('reportsDirectory', defaultReportsDirectory)) || defaultReportsDirectory;
+    const projectSearchGlobs = normalizeStringArray(
+        configuration.get<string[]>('projectSearchGlobs', defaultProjectSearchGlobs),
+        defaultProjectSearchGlobs
+    );
+    const preserveRunLogs = configuration.get<boolean>('preserveRunLogs', true) !== false;
+
+    return {
+        vivadoPath,
+        vivadoExecutablePath,
+        vivadoSettingsScript,
+        projectSearchGlobs,
+        reportsDirectory,
+        preserveRunLogs,
+        resolvedExecutablePath: resolveVivadoExecutablePath(vivadoExecutablePath, vivadoPath, platform),
+        pathEntries: resolveVivadoPathEntries(vivadoExecutablePath, vivadoPath, platform),
+    };
+}
+
+export function resolveVivadoExecutablePath(
+    vivadoExecutablePath: string | undefined,
+    vivadoPath: string | undefined,
+    platform: NodeJS.Platform = process.platform,
+): string {
+    const explicitExecutable = normalizeStringSetting(vivadoExecutablePath);
+    if (explicitExecutable) {
+        return explicitExecutable;
+    }
+
+    const binPath = resolveVivadoBinPath(vivadoPath, platform);
+    if (binPath) {
+        return getPathApi(platform).join(binPath, getVivadoExecutableName(platform));
+    }
+
+    return getVivadoExecutableName(platform);
+}
+
+export function resolveVivadoBinPath(vivadoPath: string | undefined, platform: NodeJS.Platform = process.platform): string | undefined {
+    const normalizedVivadoPath = normalizeStringSetting(vivadoPath).replace(/[\\/]+$/, '');
+    if (!normalizedVivadoPath) {
+        return undefined;
+    }
+
+    const pathApi = getPathApi(platform);
+    if (pathApi.basename(normalizedVivadoPath).toLowerCase() === 'bin') {
+        return normalizedVivadoPath;
+    }
+
+    return pathApi.join(normalizedVivadoPath, 'bin');
+}
+
+export function getVivadoExecutableName(platform: NodeJS.Platform = process.platform): string {
+    return platform === 'win32' ? 'vivado.bat' : 'vivado';
+}
+
+function resolveVivadoPathEntries(
+    vivadoExecutablePath: string | undefined,
+    vivadoPath: string | undefined,
+    platform: NodeJS.Platform,
+): string[] {
+    const pathApi = getPathApi(platform);
+    const entries: string[] = [];
+    const explicitExecutable = normalizeStringSetting(vivadoExecutablePath);
+
+    if (explicitExecutable && looksLikePath(explicitExecutable, platform)) {
+        const executableDir = pathApi.dirname(explicitExecutable);
+        if (executableDir && executableDir !== '.') {
+            entries.push(executableDir);
+        }
+    }
+
+    const binPath = resolveVivadoBinPath(vivadoPath, platform);
+    if (binPath) {
+        entries.push(binPath);
+    }
+
+    return [...new Set(entries)];
+}
+
+function looksLikePath(value: string, platform: NodeJS.Platform): boolean {
+    return value.includes('/') || value.includes('\\') || getPathApi(platform).isAbsolute(value);
+}
+
+function getPathApi(platform: NodeJS.Platform): path.PlatformPath {
+    return platform === 'win32' ? path.win32 : path.posix;
+}
+
+function normalizeStringSetting(value: string | undefined): string {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeStringArray(value: unknown, fallback: string[]): string[] {
+    if (!Array.isArray(value)) {
+        return [...fallback];
+    }
+
+    const normalized = value
+        .filter((entry): entry is string => typeof entry === 'string')
+        .map(entry => entry.trim())
+        .filter(entry => entry.length > 0);
+
+    return normalized.length > 0 ? normalized : [...fallback];
+}


### PR DESCRIPTION
## Summary
- Add a reusable `vivadoRun(...)` helper for generated TCL content and `vivadoRunScript(...)` for checked-in TCL scripts.
- Use the Vivado settings resolver for executable, PATH, working directory, and optional settings-script command construction.
- Add tests for command construction, generated TCL handling, checked-in TCL scripts, task metadata, exit code/cancellation, cwd, and PATH.

Closes #5
Depends on #40

## Verification
- `npm test` (136 passing; includes compile and lint)
- `npm run docs:build`