### PR TITLE
feat: introduce Vivado domain models

### DIFF
--- a/src/models/vivado-block-design.ts
+++ b/src/models/vivado-block-design.ts
@@ -1,0 +1,22 @@
+import * as vscode from 'vscode';
+
+export interface VivadoBlockDesignOptions {
+    name: string;
+    uri: vscode.Uri;
+    generatedProductsDirectory?: vscode.Uri;
+    isOutOfDate?: boolean;
+}
+
+export class VivadoBlockDesign {
+    public name: string;
+    public uri: vscode.Uri;
+    public generatedProductsDirectory?: vscode.Uri;
+    public isOutOfDate: boolean;
+
+    constructor(options: VivadoBlockDesignOptions) {
+        this.name = options.name;
+        this.uri = options.uri;
+        this.generatedProductsDirectory = options.generatedProductsDirectory;
+        this.isOutOfDate = options.isOutOfDate ?? false;
+    }
+}

--- a/src/models/vivado-file.ts
+++ b/src/models/vivado-file.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+
+export enum VivadoFileKind {
+    DesignSource = 'design-source',
+    SimulationSource = 'simulation-source',
+    Constraint = 'constraint',
+    Tcl = 'tcl',
+    Other = 'other',
+}
+
+export interface VivadoFileOptions {
+    uri: vscode.Uri;
+    kind: VivadoFileKind;
+    library?: string;
+    filesetName?: string;
+}
+
+export class VivadoFile {
+    public uri: vscode.Uri;
+    public kind: VivadoFileKind;
+    public library?: string;
+    public filesetName?: string;
+
+    constructor(options: VivadoFileOptions) {
+        this.uri = options.uri;
+        this.kind = options.kind;
+        this.library = options.library;
+        this.filesetName = options.filesetName;
+    }
+}

--- a/src/models/vivado-fileset.ts
+++ b/src/models/vivado-fileset.ts
@@ -1,0 +1,38 @@
+import { VivadoFile, VivadoFileKind } from './vivado-file';
+
+export enum VivadoFilesetKind {
+    Sources = 'sources',
+    Simulation = 'simulation',
+    Constraints = 'constraints',
+    Other = 'other',
+}
+
+export interface VivadoFilesetOptions {
+    name: string;
+    kind: VivadoFilesetKind;
+    files?: VivadoFile[];
+}
+
+export class VivadoFileset {
+    public name: string;
+    public kind: VivadoFilesetKind;
+    public files: VivadoFile[];
+
+    constructor(options: VivadoFilesetOptions) {
+        this.name = options.name;
+        this.kind = options.kind;
+        this.files = options.files ?? [];
+    }
+
+    public get designSources(): VivadoFile[] {
+        return this.files.filter(file => file.kind === VivadoFileKind.DesignSource);
+    }
+
+    public get simulationSources(): VivadoFile[] {
+        return this.files.filter(file => file.kind === VivadoFileKind.SimulationSource);
+    }
+
+    public get constraints(): VivadoFile[] {
+        return this.files.filter(file => file.kind === VivadoFileKind.Constraint);
+    }
+}

--- a/src/models/vivado-ip.ts
+++ b/src/models/vivado-ip.ts
@@ -1,0 +1,28 @@
+import * as vscode from 'vscode';
+
+export interface VivadoIpOptions {
+    name: string;
+    uri: vscode.Uri;
+    vendor?: string;
+    library?: string;
+    version?: string;
+    status?: string;
+}
+
+export class VivadoIp {
+    public name: string;
+    public uri: vscode.Uri;
+    public vendor?: string;
+    public library?: string;
+    public version?: string;
+    public status?: string;
+
+    constructor(options: VivadoIpOptions) {
+        this.name = options.name;
+        this.uri = options.uri;
+        this.vendor = options.vendor;
+        this.library = options.library;
+        this.version = options.version;
+        this.status = options.status;
+    }
+}

--- a/src/models/vivado-project.ts
+++ b/src/models/vivado-project.ts
@@ -1,0 +1,85 @@
+import path from 'path';
+import * as vscode from 'vscode';
+import { VivadoBlockDesign } from './vivado-block-design';
+import { VivadoFile } from './vivado-file';
+import { VivadoFileset } from './vivado-fileset';
+import { VivadoIp } from './vivado-ip';
+import { VivadoReport } from './vivado-report';
+import { VivadoRun, VivadoRunType } from './vivado-run';
+
+export interface VivadoProjectOptions {
+    name: string;
+    uri: vscode.Uri;
+    xprFile: vscode.Uri;
+    part?: string;
+    boardPart?: string;
+    topModule?: string;
+    filesets?: VivadoFileset[];
+    ips?: VivadoIp[];
+    blockDesigns?: VivadoBlockDesign[];
+    runs?: VivadoRun[];
+    reports?: VivadoReport[];
+}
+
+export class VivadoProject {
+    public name: string;
+    public uri: vscode.Uri;
+    public xprFile: vscode.Uri;
+    public part?: string;
+    public boardPart?: string;
+    public topModule?: string;
+    public filesets: VivadoFileset[];
+    public ips: VivadoIp[];
+    public blockDesigns: VivadoBlockDesign[];
+    public runs: VivadoRun[];
+    public reports: VivadoReport[];
+
+    constructor(options: VivadoProjectOptions) {
+        this.name = options.name;
+        this.uri = options.uri;
+        this.xprFile = options.xprFile;
+        this.part = options.part;
+        this.boardPart = options.boardPart;
+        this.topModule = options.topModule;
+        this.filesets = options.filesets ?? [];
+        this.ips = options.ips ?? [];
+        this.blockDesigns = options.blockDesigns ?? [];
+        this.runs = options.runs ?? [];
+        this.reports = options.reports ?? [];
+    }
+
+    public static fromXprUri(
+        xprFile: vscode.Uri,
+        options: Partial<Omit<VivadoProjectOptions, 'uri' | 'xprFile'>> = {},
+    ): VivadoProject {
+        const uri = vscode.Uri.joinPath(xprFile, '..');
+        const name = options.name ?? path.basename(xprFile.fsPath, path.extname(xprFile.fsPath));
+
+        return new VivadoProject({
+            ...options,
+            name,
+            uri,
+            xprFile,
+        });
+    }
+
+    public get files(): VivadoFile[] {
+        return this.filesets.flatMap(fileset => fileset.files);
+    }
+
+    public get designSources(): VivadoFile[] {
+        return this.filesets.flatMap(fileset => fileset.designSources);
+    }
+
+    public get simulationSources(): VivadoFile[] {
+        return this.filesets.flatMap(fileset => fileset.simulationSources);
+    }
+
+    public get constraints(): VivadoFile[] {
+        return this.filesets.flatMap(fileset => fileset.constraints);
+    }
+
+    public runsByType(type: VivadoRunType): VivadoRun[] {
+        return this.runs.filter(run => run.type === type);
+    }
+}

--- a/src/models/vivado-report.ts
+++ b/src/models/vivado-report.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+
+export enum VivadoReportKind {
+    Timing = 'timing',
+    Utilization = 'utilization',
+    Power = 'power',
+    Drc = 'drc',
+    Other = 'other',
+}
+
+export interface VivadoReportOptions {
+    name: string;
+    uri: vscode.Uri;
+    kind: VivadoReportKind;
+    runName?: string;
+}
+
+export class VivadoReport {
+    public name: string;
+    public uri: vscode.Uri;
+    public kind: VivadoReportKind;
+    public runName?: string;
+
+    constructor(options: VivadoReportOptions) {
+        this.name = options.name;
+        this.uri = options.uri;
+        this.kind = options.kind;
+        this.runName = options.runName;
+    }
+}

--- a/src/models/vivado-run.ts
+++ b/src/models/vivado-run.ts
@@ -1,0 +1,38 @@
+export enum VivadoRunType {
+    Synthesis = 'synthesis',
+    Implementation = 'implementation',
+    Simulation = 'simulation',
+    Other = 'other',
+}
+
+export enum VivadoRunStatus {
+    NotStarted = 'not-started',
+    Running = 'running',
+    Complete = 'complete',
+    Failed = 'failed',
+    Unknown = 'unknown',
+}
+
+export interface VivadoRunOptions {
+    name: string;
+    type: VivadoRunType;
+    status?: VivadoRunStatus;
+    strategy?: string;
+    parentRunName?: string;
+}
+
+export class VivadoRun {
+    public name: string;
+    public type: VivadoRunType;
+    public status: VivadoRunStatus;
+    public strategy?: string;
+    public parentRunName?: string;
+
+    constructor(options: VivadoRunOptions) {
+        this.name = options.name;
+        this.type = options.type;
+        this.status = options.status ?? VivadoRunStatus.Unknown;
+        this.strategy = options.strategy;
+        this.parentRunName = options.parentRunName;
+    }
+}

--- a/src/test/models/vivado-project.test.ts
+++ b/src/test/models/vivado-project.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the initial Vivado domain model layer.
+ * Covers #7 - Introduce Vivado domain models.
+ */
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { HLSProject } from '../../models/hls-project';
+import { VivadoBlockDesign } from '../../models/vivado-block-design';
+import { VivadoFile, VivadoFileKind } from '../../models/vivado-file';
+import { VivadoFileset, VivadoFilesetKind } from '../../models/vivado-fileset';
+import { VivadoIp } from '../../models/vivado-ip';
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoReport, VivadoReportKind } from '../../models/vivado-report';
+import { VivadoRun, VivadoRunStatus, VivadoRunType } from '../../models/vivado-run';
+
+function uri(filePath: string): vscode.Uri {
+    return vscode.Uri.file(filePath);
+}
+
+function makeProject(): VivadoProject {
+    const projectRoot = uri(path.join('/workspace', 'board-design'));
+    const sourceFile = new VivadoFile({
+        uri: uri(path.join('/workspace', 'board-design', 'src', 'top.sv')),
+        kind: VivadoFileKind.DesignSource,
+        library: 'xil_defaultlib',
+        filesetName: 'sources_1',
+    });
+    const simulationFile = new VivadoFile({
+        uri: uri(path.join('/workspace', 'board-design', 'sim', 'top_tb.sv')),
+        kind: VivadoFileKind.SimulationSource,
+        filesetName: 'sim_1',
+    });
+    const constraintFile = new VivadoFile({
+        uri: uri(path.join('/workspace', 'board-design', 'constraints', 'top.xdc')),
+        kind: VivadoFileKind.Constraint,
+        filesetName: 'constrs_1',
+    });
+
+    return new VivadoProject({
+        name: 'board-design',
+        uri: projectRoot,
+        xprFile: vscode.Uri.joinPath(projectRoot, 'board-design.xpr'),
+        part: 'xc7a200tsbg484-1',
+        boardPart: 'digilentinc.com:arty-a7-100:part0:1.1',
+        topModule: 'top',
+        filesets: [
+            new VivadoFileset({
+                name: 'sources_1',
+                kind: VivadoFilesetKind.Sources,
+                files: [sourceFile],
+            }),
+            new VivadoFileset({
+                name: 'sim_1',
+                kind: VivadoFilesetKind.Simulation,
+                files: [simulationFile],
+            }),
+            new VivadoFileset({
+                name: 'constrs_1',
+                kind: VivadoFilesetKind.Constraints,
+                files: [constraintFile],
+            }),
+        ],
+        ips: [
+            new VivadoIp({
+                name: 'clk_wiz_0',
+                uri: uri(path.join('/workspace', 'board-design', 'ip', 'clk_wiz_0.xci')),
+                vendor: 'xilinx.com',
+                library: 'ip',
+                version: '6.0',
+                status: 'locked',
+            }),
+        ],
+        blockDesigns: [
+            new VivadoBlockDesign({
+                name: 'system',
+                uri: uri(path.join('/workspace', 'board-design', 'bd', 'system.bd')),
+                isOutOfDate: true,
+            }),
+        ],
+        runs: [
+            new VivadoRun({
+                name: 'synth_1',
+                type: VivadoRunType.Synthesis,
+                status: VivadoRunStatus.Complete,
+                strategy: 'Vivado Synthesis Defaults',
+            }),
+            new VivadoRun({
+                name: 'impl_1',
+                type: VivadoRunType.Implementation,
+                status: VivadoRunStatus.Running,
+                parentRunName: 'synth_1',
+            }),
+        ],
+        reports: [
+            new VivadoReport({
+                name: 'timing-summary',
+                uri: uri(path.join('/workspace', 'board-design', 'reports', 'timing_summary.rpt')),
+                kind: VivadoReportKind.Timing,
+                runName: 'impl_1',
+            }),
+        ],
+    });
+}
+
+suite('VivadoProject', () => {
+    test('fromXprUri derives project name and root URI from the .xpr path', () => {
+        const xprFile = uri(path.join('/workspace', 'blink', 'blink.xpr'));
+        const project = VivadoProject.fromXprUri(xprFile);
+
+        assert.strictEqual(project.name, 'blink');
+        assert.strictEqual(project.uri.fsPath, vscode.Uri.joinPath(xprFile, '..').fsPath);
+        assert.strictEqual(project.xprFile.fsPath, xprFile.fsPath);
+    });
+
+    test('stores Vivado project metadata without requiring Vivado to launch', () => {
+        const project = makeProject();
+
+        assert.strictEqual(project.part, 'xc7a200tsbg484-1');
+        assert.strictEqual(project.boardPart, 'digilentinc.com:arty-a7-100:part0:1.1');
+        assert.strictEqual(project.topModule, 'top');
+    });
+
+    test('keeps Vivado and HLS project concepts separate', () => {
+        const vivadoProject = makeProject();
+        const hlsProject = new HLSProject(uri(path.join('/workspace', 'hls', 'hls.app')), 'hls', 'top');
+
+        assert.ok(!(vivadoProject instanceof HLSProject));
+        assert.ok(!(hlsProject instanceof VivadoProject));
+        assert.strictEqual((vivadoProject as any).solutions, undefined);
+        assert.strictEqual((hlsProject as any).filesets, undefined);
+    });
+
+    test('flattens design, simulation, and constraint files for shared UI consumers', () => {
+        const project = makeProject();
+
+        assert.deepStrictEqual(project.designSources.map(file => path.basename(file.uri.fsPath)), ['top.sv']);
+        assert.deepStrictEqual(project.simulationSources.map(file => path.basename(file.uri.fsPath)), ['top_tb.sv']);
+        assert.deepStrictEqual(project.constraints.map(file => path.basename(file.uri.fsPath)), ['top.xdc']);
+        assert.strictEqual(project.files.length, 3);
+    });
+
+    test('captures IP, block design, run, and report metadata', () => {
+        const project = makeProject();
+
+        assert.strictEqual(project.ips[0].name, 'clk_wiz_0');
+        assert.strictEqual(project.ips[0].status, 'locked');
+        assert.strictEqual(project.blockDesigns[0].name, 'system');
+        assert.strictEqual(project.blockDesigns[0].isOutOfDate, true);
+        assert.strictEqual(project.reports[0].kind, VivadoReportKind.Timing);
+        assert.strictEqual(project.reports[0].runName, 'impl_1');
+    });
+
+    test('filters runs by Vivado run type', () => {
+        const project = makeProject();
+
+        assert.deepStrictEqual(project.runsByType(VivadoRunType.Synthesis).map(run => run.name), ['synth_1']);
+        assert.deepStrictEqual(project.runsByType(VivadoRunType.Implementation).map(run => run.name), ['impl_1']);
+        assert.deepStrictEqual(project.runsByType(VivadoRunType.Simulation), []);
+    });
+});
+
+suite('VivadoFileset', () => {
+    test('defaults to an empty file list', () => {
+        const fileset = new VivadoFileset({
+            name: 'sources_1',
+            kind: VivadoFilesetKind.Sources,
+        });
+
+        assert.deepStrictEqual(fileset.files, []);
+        assert.deepStrictEqual(fileset.designSources, []);
+    });
+});
+
+suite('VivadoRun', () => {
+    test('defaults run status to unknown', () => {
+        const run = new VivadoRun({
+            name: 'synth_1',
+            type: VivadoRunType.Synthesis,
+        });
+
+        assert.strictEqual(run.status, VivadoRunStatus.Unknown);
+    });
+});


### PR DESCRIPTION
## Summary
- Add explicit Vivado model classes for projects, files, filesets, runs, IP, block designs, and reports.
- Keep Vivado concepts separate from the inherited HLS project/solution/file model.
- Add model helpers for shared UI consumers to flatten design sources, simulation sources, constraints, and filter runs by type.
- Add tests for metadata storage, HLS/Vivado separation, file flattening, run filtering, and default values without launching Vivado.

Closes #7

## Verification
- `npm test` (150 passing; includes compile and lint)
- `npm run docs:build`