### PR TITLE
feat: add Vivado project discovery

### DIFF
--- a/src/test/utils/vivado-xpr.test.ts
+++ b/src/test/utils/vivado-xpr.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for safe Vivado .xpr metadata loading.
+ * Covers #8 - Add Vivado project discovery and metadata loading.
+ */
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { VivadoFileKind } from '../../models/vivado-file';
+import { VivadoFilesetKind } from '../../models/vivado-fileset';
+import { VivadoRunStatus, VivadoRunType } from '../../models/vivado-run';
+import { parseVivadoProjectXml } from '../../utils/vivado-xpr';
+
+const SAMPLE_XPR = `<?xml version="1.0" encoding="UTF-8"?>
+<Project Version="7" Minor="60" Path="mock_vivado_project.xpr">
+  <Configuration>
+    <Option Name="ProjectName" Val="mock_vivado_project" />
+    <Option Name="Part" Val="xc7a35tcpg236-1" />
+    <Option Name="BoardPart" Val="digilentinc.com:arty-a7-35:part0:1.0" />
+    <Option Name="TopModule" Val="counter" />
+  </Configuration>
+  <FileSets>
+    <FileSet Name="sources_1" Type="DesignSrcs">
+      <File Path="$PPRDIR/../src/rtl/counter.sv" Library="xil_defaultlib" />
+      <File Path="$PPRDIR/../ip/clk_wiz_0.xci" />
+      <File Path="$PPRDIR/../bd/system.bd" />
+    </FileSet>
+    <FileSet Name="sim_1" Type="SimulationSrcs">
+      <File Path="$PPRDIR/../src/sim/counter_tb.sv" />
+    </FileSet>
+    <FileSet Name="constrs_1" Type="Constrs">
+      <File Path="$PPRDIR/../constraints/counter.xdc" />
+    </FileSet>
+  </FileSets>
+  <Runs>
+    <Run Id="synth_1" Type="Ft3:Synth" Part="xc7a35tcpg236-1" Status="complete" Strategy="Vivado Synthesis Defaults" />
+    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a35tcpg236-1" Status="running" Parent="synth_1" />
+  </Runs>
+</Project>`;
+
+function xprUri(projectName: string = 'mock_vivado_project'): vscode.Uri {
+    return vscode.Uri.file(path.join('/workspace', projectName, `${projectName}.xpr`));
+}
+
+suite('Vivado XPR metadata loading', () => {
+    test('loads project identity and board metadata from a .xpr file', async () => {
+        const project = await parseVivadoProjectXml(SAMPLE_XPR, xprUri());
+
+        assert.strictEqual(project.name, 'mock_vivado_project');
+        assert.strictEqual(project.part, 'xc7a35tcpg236-1');
+        assert.strictEqual(project.boardPart, 'digilentinc.com:arty-a7-35:part0:1.0');
+        assert.strictEqual(project.topModule, 'counter');
+    });
+
+    test('falls back to the .xpr file name when ProjectName is absent', async () => {
+        const project = await parseVivadoProjectXml(
+            '<Project><Configuration /></Project>',
+            xprUri('fallback_name'),
+        );
+
+        assert.strictEqual(project.name, 'fallback_name');
+    });
+
+    test('loads filesets, files, and source categories', async () => {
+        const project = await parseVivadoProjectXml(SAMPLE_XPR, xprUri());
+
+        assert.deepStrictEqual(project.filesets.map(fileset => fileset.kind), [
+            VivadoFilesetKind.Sources,
+            VivadoFilesetKind.Simulation,
+            VivadoFilesetKind.Constraints,
+        ]);
+        assert.deepStrictEqual(project.designSources.map(file => path.basename(file.uri.fsPath)), [
+            'counter.sv',
+            'clk_wiz_0.xci',
+            'system.bd',
+        ]);
+        assert.deepStrictEqual(project.simulationSources.map(file => path.basename(file.uri.fsPath)), ['counter_tb.sv']);
+        assert.deepStrictEqual(project.constraints.map(file => path.basename(file.uri.fsPath)), ['counter.xdc']);
+        assert.strictEqual(project.designSources[0].kind, VivadoFileKind.DesignSource);
+        assert.strictEqual(project.designSources[0].library, 'xil_defaultlib');
+    });
+
+    test('resolves $PPRDIR paths relative to the project file directory', async () => {
+        const project = await parseVivadoProjectXml(SAMPLE_XPR, xprUri());
+        const source = project.designSources.find(file => path.basename(file.uri.fsPath) === 'counter.sv');
+
+        assert.strictEqual(
+            source?.uri.fsPath,
+            path.normalize(path.join('/workspace', 'src', 'rtl', 'counter.sv')),
+        );
+    });
+
+    test('loads IP and block design entries from .xci and .bd files', async () => {
+        const project = await parseVivadoProjectXml(SAMPLE_XPR, xprUri());
+
+        assert.deepStrictEqual(project.ips.map(ip => ip.name), ['clk_wiz_0']);
+        assert.deepStrictEqual(project.blockDesigns.map(blockDesign => blockDesign.name), ['system']);
+    });
+
+    test('loads synthesis and implementation runs', async () => {
+        const project = await parseVivadoProjectXml(SAMPLE_XPR, xprUri());
+
+        assert.strictEqual(project.runs[0].name, 'synth_1');
+        assert.strictEqual(project.runs[0].type, VivadoRunType.Synthesis);
+        assert.strictEqual(project.runs[0].status, VivadoRunStatus.Complete);
+        assert.strictEqual(project.runs[0].strategy, 'Vivado Synthesis Defaults');
+        assert.strictEqual(project.runs[1].type, VivadoRunType.Implementation);
+        assert.strictEqual(project.runs[1].status, VivadoRunStatus.Running);
+        assert.strictEqual(project.runs[1].parentRunName, 'synth_1');
+    });
+
+    test('throws a useful error when the file is not a Vivado project XML document', async () => {
+        await assert.rejects(
+            () => parseVivadoProjectXml('<NotProject />', xprUri()),
+            /missing Project root element/,
+        );
+    });
+});

--- a/src/test/utils/vivado-xpr.test.ts
+++ b/src/test/utils/vivado-xpr.test.ts
@@ -79,6 +79,26 @@ suite('Vivado XPR metadata loading', () => {
         assert.strictEqual(project.designSources[0].library, 'xil_defaultlib');
     });
 
+    test('skips file entries without usable paths', async () => {
+        const project = await parseVivadoProjectXml(
+            `<Project>
+              <FileSets>
+                <FileSet Name="sources_1" Type="DesignSrcs">
+                  <File />
+                  <File Path="   " />
+                  <File Path="$PPRDIR/src/top.sv" />
+                </FileSet>
+              </FileSets>
+            </Project>`,
+            xprUri(),
+        );
+
+        assert.strictEqual(project.filesets[0].files.length, 1);
+        assert.deepStrictEqual(project.designSources.map(file => path.basename(file.uri.fsPath)), ['top.sv']);
+        assert.deepStrictEqual(project.ips, []);
+        assert.deepStrictEqual(project.blockDesigns, []);
+    });
+
     test('resolves $PPRDIR paths relative to the project file directory', async () => {
         const project = await parseVivadoProjectXml(SAMPLE_XPR, xprUri());
         const source = project.designSources.find(file => path.basename(file.uri.fsPath) === 'counter.sv');

--- a/src/test/vivado-project-manager.test.ts
+++ b/src/test/vivado-project-manager.test.ts
@@ -55,9 +55,11 @@ function makeManager(dependencies: Partial<VivadoProjectManagerDependencies>): {
 suite('VivadoProjectManager', () => {
     test('discovers .xpr projects using configured globs', async () => {
         const xprFile = vscode.Uri.file(path.join('/workspace', 'demo', 'demo.xpr'));
+        const maxResultsValues: Array<number | undefined> = [];
         const { manager, findCalls } = makeManager({
-            findFiles: (include) => {
+            findFiles: (include, _exclude, maxResults) => {
                 findCalls.push(include.toString());
+                maxResultsValues.push(maxResults);
                 return Promise.resolve([xprFile]);
             },
         });
@@ -66,6 +68,7 @@ suite('VivadoProjectManager', () => {
         const projects = await manager.getProjects();
 
         assert.deepStrictEqual(findCalls, ['**/*.xpr']);
+        assert.deepStrictEqual(maxResultsValues, [undefined]);
         assert.strictEqual(projects.length, 1);
         assert.strictEqual(projects[0].name, 'demo');
         assert.strictEqual(projects, manager.projects);

--- a/src/test/vivado-project-manager.test.ts
+++ b/src/test/vivado-project-manager.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for Vivado project discovery.
+ * Covers #8 - Add Vivado project discovery and metadata loading.
+ */
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { VivadoProject } from '../models/vivado-project';
+import { VivadoSettings } from '../utils/vivado-settings';
+import VivadoProjectManager, { VivadoProjectManagerDependencies } from '../vivado-project-manager';
+
+function makeSettings(overrides: Partial<VivadoSettings> = {}): VivadoSettings {
+    return {
+        vivadoPath: '',
+        vivadoExecutablePath: '',
+        vivadoSettingsScript: '',
+        projectSearchGlobs: ['**/*.xpr'],
+        reportsDirectory: 'reports',
+        generatedTclDirectory: '.vscode-vivado/tcl',
+        preserveRunLogs: true,
+        resolvedExecutablePath: '',
+        pathEntries: [],
+        ...overrides,
+    };
+}
+
+function makeProject(xprFile: vscode.Uri): VivadoProject {
+    return VivadoProject.fromXprUri(xprFile, {
+        part: 'xc7a35tcpg236-1',
+        topModule: 'counter',
+    });
+}
+
+function makeManager(dependencies: Partial<VivadoProjectManagerDependencies>): {
+    manager: VivadoProjectManager;
+    messages: string[];
+    findCalls: string[];
+} {
+    const messages: string[] = [];
+    const findCalls: string[] = [];
+    const manager = new VivadoProjectManager({
+        findFiles: (include) => {
+            findCalls.push(include.toString());
+            return Promise.resolve([]);
+        },
+        getSettings: () => makeSettings(),
+        loadProject: async file => makeProject(file),
+        appendLine: message => messages.push(message),
+        ...dependencies,
+    }, false);
+
+    return { manager, messages, findCalls };
+}
+
+suite('VivadoProjectManager', () => {
+    test('discovers .xpr projects using configured globs', async () => {
+        const xprFile = vscode.Uri.file(path.join('/workspace', 'demo', 'demo.xpr'));
+        const { manager, findCalls } = makeManager({
+            findFiles: (include) => {
+                findCalls.push(include.toString());
+                return Promise.resolve([xprFile]);
+            },
+        });
+
+        manager.refresh();
+        const projects = await manager.getProjects();
+
+        assert.deepStrictEqual(findCalls, ['**/*.xpr']);
+        assert.strictEqual(projects.length, 1);
+        assert.strictEqual(projects[0].name, 'demo');
+        assert.strictEqual(projects, manager.projects);
+    });
+
+    test('uses all configured project search globs and deduplicates repeated files', async () => {
+        const xprFile = vscode.Uri.file(path.join('/workspace', 'demo', 'demo.xpr'));
+        const { manager, findCalls } = makeManager({
+            getSettings: () => makeSettings({
+                projectSearchGlobs: ['projects/**/*.xpr', '**/*.xpr'],
+            }),
+            findFiles: (include) => {
+                findCalls.push(include.toString());
+                return Promise.resolve([xprFile]);
+            },
+        });
+
+        manager.refresh();
+        const projects = await manager.getProjects();
+
+        assert.deepStrictEqual(findCalls, ['projects/**/*.xpr', '**/*.xpr']);
+        assert.strictEqual(projects.length, 1);
+    });
+
+    test('handles metadata loading failures without dropping valid projects', async () => {
+        const goodProject = vscode.Uri.file(path.join('/workspace', 'good', 'good.xpr'));
+        const badProject = vscode.Uri.file(path.join('/workspace', 'bad', 'bad.xpr'));
+        const { manager, messages } = makeManager({
+            findFiles: () => Promise.resolve([goodProject, badProject]),
+            loadProject: async file => {
+                if (file.fsPath === badProject.fsPath) {
+                    throw new Error('malformed xpr');
+                }
+
+                return makeProject(file);
+            },
+        });
+
+        manager.refresh();
+        const projects = await manager.getProjects();
+
+        assert.strictEqual(projects.length, 1);
+        assert.strictEqual(projects[0].name, 'good');
+        assert.ok(messages.some(message => message.includes('Error loading Vivado project: malformed xpr')));
+    });
+
+    test('handles discovery search failures without throwing from getProjects', async () => {
+        const { manager, messages } = makeManager({
+            findFiles: () => Promise.reject(new Error('search failed')),
+        });
+
+        manager.refresh();
+        const projects = await manager.getProjects();
+
+        assert.deepStrictEqual(projects, []);
+        assert.ok(messages.some(message => message.includes('Error discovering Vivado projects: search failed')));
+    });
+
+    test('does not require a configured Vivado executable for .xpr discovery', async () => {
+        const xprFile = vscode.Uri.file(path.join('/workspace', 'no-vivado', 'no-vivado.xpr'));
+        const { manager } = makeManager({
+            getSettings: () => makeSettings({
+                vivadoPath: '',
+                vivadoExecutablePath: '',
+                resolvedExecutablePath: '',
+                pathEntries: [],
+            }),
+            findFiles: () => Promise.resolve([xprFile]),
+        });
+
+        manager.refresh();
+        const projects = await manager.getProjects();
+
+        assert.strictEqual(projects.length, 1);
+        assert.strictEqual(projects[0].name, 'no-vivado');
+    });
+
+    test('replaces stale project entries on refresh', async () => {
+        const firstProject = vscode.Uri.file(path.join('/workspace', 'first', 'first.xpr'));
+        const secondProject = vscode.Uri.file(path.join('/workspace', 'second', 'second.xpr'));
+        let refreshCount = 0;
+        const { manager } = makeManager({
+            findFiles: () => {
+                refreshCount += 1;
+                return Promise.resolve(refreshCount === 1 ? [firstProject] : [secondProject]);
+            },
+        });
+
+        manager.refresh();
+        assert.deepStrictEqual((await manager.getProjects()).map(project => project.name), ['first']);
+
+        manager.refresh();
+        assert.deepStrictEqual((await manager.getProjects()).map(project => project.name), ['second']);
+    });
+
+    test('fires projectsChanged after refresh completes', async () => {
+        const xprFile = vscode.Uri.file(path.join('/workspace', 'demo', 'demo.xpr'));
+        const { manager } = makeManager({
+            findFiles: () => Promise.resolve([xprFile]),
+        });
+
+        let fired = false;
+        manager.once('projectsChanged', () => { fired = true; });
+
+        manager.refresh();
+        await manager.getProjects();
+
+        assert.strictEqual(fired, true);
+    });
+});

--- a/src/utils/vivado-xpr.ts
+++ b/src/utils/vivado-xpr.ts
@@ -1,0 +1,205 @@
+import path from 'path';
+import * as vscode from 'vscode';
+import xml2js from 'xml2js';
+import { VivadoBlockDesign } from '../models/vivado-block-design';
+import { VivadoFile, VivadoFileKind } from '../models/vivado-file';
+import { VivadoFileset, VivadoFilesetKind } from '../models/vivado-fileset';
+import { VivadoIp } from '../models/vivado-ip';
+import { VivadoProject } from '../models/vivado-project';
+import { VivadoRun, VivadoRunStatus, VivadoRunType } from '../models/vivado-run';
+
+interface XmlNode {
+    $?: Record<string, string | undefined>;
+    [key: string]: unknown;
+}
+
+export async function loadVivadoProjectFromXpr(xprFile: vscode.Uri): Promise<VivadoProject> {
+    const data = await vscode.workspace.fs.readFile(xprFile);
+    return parseVivadoProjectXml(Buffer.from(data).toString(), xprFile);
+}
+
+export async function parseVivadoProjectXml(xml: string, xprFile: vscode.Uri): Promise<VivadoProject> {
+    const parsed = await xml2js.parseStringPromise(xml) as { Project?: XmlNode };
+    const projectNode = parsed.Project;
+
+    if (!projectNode) {
+        throw new Error('Invalid Vivado project file: missing Project root element.');
+    }
+
+    const projectRoot = vscode.Uri.joinPath(xprFile, '..');
+    const options = readConfigurationOptions(projectNode);
+    const filesets = readFilesets(projectNode, projectRoot);
+    const files = filesets.flatMap(fileset => fileset.files);
+
+    return new VivadoProject({
+        name: options.get('ProjectName') ?? path.basename(xprFile.fsPath, path.extname(xprFile.fsPath)),
+        uri: projectRoot,
+        xprFile,
+        part: options.get('Part') ?? readFirstRunPart(projectNode),
+        boardPart: options.get('BoardPart'),
+        topModule: options.get('TopModule'),
+        filesets,
+        ips: files
+            .filter(file => path.extname(file.uri.fsPath).toLowerCase() === '.xci')
+            .map(file => new VivadoIp({
+                name: path.basename(file.uri.fsPath, path.extname(file.uri.fsPath)),
+                uri: file.uri,
+            })),
+        blockDesigns: files
+            .filter(file => path.extname(file.uri.fsPath).toLowerCase() === '.bd')
+            .map(file => new VivadoBlockDesign({
+                name: path.basename(file.uri.fsPath, path.extname(file.uri.fsPath)),
+                uri: file.uri,
+            })),
+        runs: readRuns(projectNode),
+    });
+}
+
+function readConfigurationOptions(projectNode: XmlNode): Map<string, string> {
+    const options = new Map<string, string>();
+    const configuration = firstNode(projectNode.Configuration);
+
+    for (const option of nodeArray(configuration?.Option)) {
+        const name = option.$?.Name;
+        const value = option.$?.Val;
+        if (name && value !== undefined) {
+            options.set(name, value);
+        }
+    }
+
+    return options;
+}
+
+function readFilesets(projectNode: XmlNode, projectRoot: vscode.Uri): VivadoFileset[] {
+    const fileSetsNode = firstNode(projectNode.FileSets);
+
+    return nodeArray(fileSetsNode?.FileSet).map(filesetNode => {
+        const name = filesetNode.$?.Name ?? 'unnamed';
+        const kind = mapFilesetKind(filesetNode.$?.Type);
+
+        return new VivadoFileset({
+            name,
+            kind,
+            files: nodeArray(filesetNode.File).map(fileNode => new VivadoFile({
+                uri: resolveVivadoProjectPath(projectRoot, fileNode.$?.Path ?? ''),
+                kind: mapFileKind(kind, fileNode.$?.Path),
+                library: fileNode.$?.Library,
+                filesetName: name,
+            })),
+        });
+    });
+}
+
+function readRuns(projectNode: XmlNode): VivadoRun[] {
+    const runsNode = firstNode(projectNode.Runs);
+
+    return nodeArray(runsNode?.Run).map(runNode => new VivadoRun({
+        name: runNode.$?.Id ?? runNode.$?.Name ?? 'unnamed',
+        type: mapRunType(runNode.$?.Type),
+        status: mapRunStatus(runNode.$?.Status),
+        strategy: runNode.$?.Strategy,
+        parentRunName: runNode.$?.Parent ?? runNode.$?.ParentRun,
+    }));
+}
+
+function readFirstRunPart(projectNode: XmlNode): string | undefined {
+    const runsNode = firstNode(projectNode.Runs);
+    return nodeArray(runsNode?.Run).find(runNode => runNode.$?.Part)?.$?.Part;
+}
+
+function resolveVivadoProjectPath(projectRoot: vscode.Uri, filePath: string): vscode.Uri {
+    const projectRootPath = projectRoot.fsPath;
+    const expandedPath = filePath.replace(/\$PPRDIR/g, projectRootPath);
+    const resolvedPath = path.isAbsolute(expandedPath)
+        ? expandedPath
+        : path.join(projectRootPath, expandedPath);
+
+    return vscode.Uri.file(path.normalize(resolvedPath));
+}
+
+function mapFilesetKind(type: string | undefined): VivadoFilesetKind {
+    switch ((type ?? '').toLowerCase()) {
+        case 'designsrcs':
+            return VivadoFilesetKind.Sources;
+        case 'simulationsrcs':
+            return VivadoFilesetKind.Simulation;
+        case 'constrs':
+            return VivadoFilesetKind.Constraints;
+        default:
+            return VivadoFilesetKind.Other;
+    }
+}
+
+function mapFileKind(filesetKind: VivadoFilesetKind, filePath: string | undefined): VivadoFileKind {
+    const extension = path.extname(filePath ?? '').toLowerCase();
+
+    if (extension === '.xdc') {
+        return VivadoFileKind.Constraint;
+    }
+
+    if (extension === '.tcl') {
+        return VivadoFileKind.Tcl;
+    }
+
+    switch (filesetKind) {
+        case VivadoFilesetKind.Sources:
+            return VivadoFileKind.DesignSource;
+        case VivadoFilesetKind.Simulation:
+            return VivadoFileKind.SimulationSource;
+        case VivadoFilesetKind.Constraints:
+            return VivadoFileKind.Constraint;
+        default:
+            return VivadoFileKind.Other;
+    }
+}
+
+function mapRunType(type: string | undefined): VivadoRunType {
+    const normalizedType = (type ?? '').toLowerCase();
+
+    if (normalizedType.includes('synth')) {
+        return VivadoRunType.Synthesis;
+    }
+
+    if (normalizedType.includes('impl') || normalizedType.includes('entiredesign')) {
+        return VivadoRunType.Implementation;
+    }
+
+    if (normalizedType.includes('sim')) {
+        return VivadoRunType.Simulation;
+    }
+
+    return VivadoRunType.Other;
+}
+
+function mapRunStatus(status: string | undefined): VivadoRunStatus {
+    switch ((status ?? '').toLowerCase()) {
+        case 'not started':
+        case 'not-started':
+            return VivadoRunStatus.NotStarted;
+        case 'running':
+            return VivadoRunStatus.Running;
+        case 'complete':
+        case 'completed':
+            return VivadoRunStatus.Complete;
+        case 'failed':
+            return VivadoRunStatus.Failed;
+        default:
+            return VivadoRunStatus.Unknown;
+    }
+}
+
+function firstNode(value: unknown): XmlNode | undefined {
+    return nodeArray(value)[0];
+}
+
+function nodeArray(value: unknown): XmlNode[] {
+    if (!value) {
+        return [];
+    }
+
+    if (Array.isArray(value)) {
+        return value.filter((entry): entry is XmlNode => typeof entry === 'object' && entry !== null);
+    }
+
+    return typeof value === 'object' ? [value as XmlNode] : [];
+}

--- a/src/utils/vivado-xpr.ts
+++ b/src/utils/vivado-xpr.ts
@@ -80,12 +80,20 @@ function readFilesets(projectNode: XmlNode, projectRoot: vscode.Uri): VivadoFile
         return new VivadoFileset({
             name,
             kind,
-            files: nodeArray(filesetNode.File).map(fileNode => new VivadoFile({
-                uri: resolveVivadoProjectPath(projectRoot, fileNode.$?.Path ?? ''),
-                kind: mapFileKind(kind, fileNode.$?.Path),
-                library: fileNode.$?.Library,
-                filesetName: name,
-            })),
+            files: nodeArray(filesetNode.File).flatMap(fileNode => {
+                const filePath = fileNode.$?.Path?.trim();
+
+                if (!filePath) {
+                    return [];
+                }
+
+                return [new VivadoFile({
+                    uri: resolveVivadoProjectPath(projectRoot, filePath),
+                    kind: mapFileKind(kind, filePath),
+                    library: fileNode.$?.Library,
+                    filesetName: name,
+                })];
+            }),
         });
     });
 }

--- a/src/vivado-project-manager.ts
+++ b/src/vivado-project-manager.ts
@@ -1,0 +1,138 @@
+import { EventEmitter } from 'stream';
+import * as vscode from 'vscode';
+import { VivadoProject } from './models/vivado-project';
+import { OutputConsole } from './output-console';
+import { getVivadoSettings, VivadoSettings } from './utils/vivado-settings';
+import { loadVivadoProjectFromXpr } from './utils/vivado-xpr';
+
+type VivadoProjectManagerEvents = { 'projectsChanged': [] };
+
+export interface VivadoProjectManagerDependencies {
+    findFiles: (include: vscode.GlobPattern, exclude?: vscode.GlobPattern, maxResults?: number) => Thenable<vscode.Uri[]>;
+    getSettings: () => VivadoSettings;
+    loadProject: (xprFile: vscode.Uri) => Promise<VivadoProject>;
+    appendLine: (message: string) => void;
+}
+
+export default class VivadoProjectManager extends EventEmitter<VivadoProjectManagerEvents> {
+    static #instance: VivadoProjectManager;
+    public readonly projects: VivadoProject[] = [];
+    private _queueRefresh: boolean = false;
+    private _refreshing: boolean = false;
+    private readonly dependencies: VivadoProjectManagerDependencies;
+
+    constructor(
+        dependencies: Partial<VivadoProjectManagerDependencies> = {},
+        autoRefresh: boolean = true,
+    ) {
+        super();
+        this.dependencies = {
+            findFiles: vscode.workspace.findFiles.bind(vscode.workspace),
+            getSettings: getVivadoSettings,
+            loadProject: loadVivadoProjectFromXpr,
+            appendLine: message => OutputConsole.instance.appendLine(message),
+            ...dependencies,
+        };
+
+        if (autoRefresh) {
+            this.refresh();
+        }
+    }
+
+    public static get instance(): VivadoProjectManager {
+        if (!VivadoProjectManager.#instance) {
+            VivadoProjectManager.#instance = new VivadoProjectManager();
+        }
+
+        return VivadoProjectManager.#instance;
+    }
+
+    public async getProjects(): Promise<VivadoProject[]> {
+        while (this._refreshing) {
+            await new Promise(resolve => this.once('projectsChanged', () => resolve(void 0)));
+        }
+
+        return this.projects;
+    }
+
+    public refresh(): void {
+        this._queueRefresh = true;
+        this.tryRefresh();
+    }
+
+    private async tryRefresh(): Promise<void> {
+        if (this._refreshing) {
+            return;
+        }
+
+        this._refreshing = true;
+        this._queueRefresh = false;
+
+        try {
+            this.dependencies.appendLine('Refreshing Vivado projects...');
+            const newProjects = await this.safeDiscoverProjects();
+            this.replaceProjects(newProjects);
+            this.dependencies.appendLine('Found ' + this.projects.length + ' Vivado project(s)');
+        } finally {
+            this._refreshing = false;
+            this.emit('projectsChanged');
+
+            if (this._queueRefresh) {
+                void this.tryRefresh();
+            }
+        }
+    }
+
+    private async safeDiscoverProjects(): Promise<VivadoProject[]> {
+        try {
+            return await this.discoverProjects();
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.dependencies.appendLine('Error discovering Vivado projects: ' + message);
+            return [];
+        }
+    }
+
+    private async discoverProjects(): Promise<VivadoProject[]> {
+        const settings = this.dependencies.getSettings();
+        const projectFiles = await this.findProjectFiles(settings.projectSearchGlobs);
+        const projects: VivadoProject[] = [];
+
+        await Promise.all(projectFiles.map(async file => {
+            try {
+                projects.push(await this.dependencies.loadProject(file));
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                this.dependencies.appendLine('Error loading Vivado project: ' + message);
+            }
+        }));
+
+        return projects;
+    }
+
+    private async findProjectFiles(globs: string[]): Promise<vscode.Uri[]> {
+        const files: vscode.Uri[] = [];
+        const seen = new Set<string>();
+
+        for (const glob of globs) {
+            const found = await this.dependencies.findFiles(glob, '**/node_modules/**', 100);
+            for (const file of found) {
+                if (!seen.has(file.fsPath)) {
+                    seen.add(file.fsPath);
+                    files.push(file);
+                }
+            }
+        }
+
+        return files;
+    }
+
+    private replaceProjects(newProjects: VivadoProject[]): void {
+        this.projects.length = 0;
+        this.projects.push(...newProjects);
+    }
+
+    public dispose(): void {
+        this.removeAllListeners();
+    }
+}

--- a/src/vivado-project-manager.ts
+++ b/src/vivado-project-manager.ts
@@ -115,7 +115,7 @@ export default class VivadoProjectManager extends EventEmitter<VivadoProjectMana
         const seen = new Set<string>();
 
         for (const glob of globs) {
-            const found = await this.dependencies.findFiles(glob, '**/node_modules/**', 100);
+            const found = await this.dependencies.findFiles(glob, '**/node_modules/**', undefined);
             for (const file of found) {
                 if (!seen.has(file.fsPath)) {
                     seen.add(file.fsPath);


### PR DESCRIPTION
## Summary
- Add a `VivadoProjectManager` that discovers `.xpr` files using `vscode-vivado.projectSearchGlobs` and keeps Vivado project state separate from the HLS `ProjectManager`.
- Add a safe `.xpr` metadata loader for project name, part, board part, top module, filesets, files, IP, block designs, and runs.
- Handle malformed project metadata and search failures gracefully without requiring Vivado to be installed or configured.
- Add focused tests for discovery globs, deduplication, refresh replacement, failure handling, `.xpr` parsing, `$PPRDIR` path resolution, and run classification.

Closes #8

## Verification
- `npm test` (164 passing; includes compile and lint)
- `npm run docs:build`