### PR TITLE
feat: render Vivado projects in tree

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import stopCsim from './commands/project/run/projects-stop-csim';
 import stopCsynth from './commands/project/run/projects-stop-csynth';
 import { OutputConsole } from './output-console';
 import ProjectManager from './project-manager';
+import VivadoProjectManager from './vivado-project-manager';
 import ProjectsViewTreeProvider, { ProjectFileItem, ProjectSourceItem, ProjectTestBenchItem } from './views/projects-tree';
 
 // TODO Make Vitis Unified IDE optional
@@ -26,7 +27,10 @@ export function activate(context: vscode.ExtensionContext) {
 	checkCppProperties();
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand('vitis-hls-ide.projects.refresh', () => ProjectManager.instance.refresh()),
+		vscode.commands.registerCommand('vitis-hls-ide.projects.refresh', () => {
+			ProjectManager.instance.refresh();
+			VivadoProjectManager.instance.refresh();
+		}),
 		vscode.commands.registerCommand('vitis-hls-ide.projects.runCosim', runCosim),
 		vscode.commands.registerCommand('vitis-hls-ide.projects.runCsim', runCsim),
 		vscode.commands.registerCommand('vitis-hls-ide.projects.runCsynth', runCsynth),
@@ -40,6 +44,7 @@ export function activate(context: vscode.ExtensionContext) {
 		projectsViewProvider,
 		OutputConsole.instance,
 		ProjectManager.instance,
+		VivadoProjectManager.instance,
 		// Check CPP properties for HLS path when the cpp properties file is changed
 		vscode.workspace.onDidChangeTextDocument((e) => {
 			const cppPropertiesPath = vscode.workspace.workspaceFolders ?

--- a/src/test/views/projects-tree.test.ts
+++ b/src/test/views/projects-tree.test.ts
@@ -7,13 +7,49 @@ import * as vscode from 'vscode';
 import { HLSProject } from '../../models/hls-project';
 import { HLSProjectFile } from '../../models/hls-project-file';
 import { HLSProjectSolution } from '../../models/hls-project-solution';
+import { VivadoFile, VivadoFileKind } from '../../models/vivado-file';
+import { VivadoFileset, VivadoFilesetKind } from '../../models/vivado-fileset';
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoReport, VivadoReportKind } from '../../models/vivado-report';
+import { VivadoRun, VivadoRunStatus, VivadoRunType } from '../../models/vivado-run';
 import ProjectsViewTreeProvider, {
     ProjectFileItem,
     ProjectSourceItem,
     ProjectTestBenchItem,
+    VivadoProjectFileItem,
+    VivadoProjectTreeItem,
+    VivadoReportTreeItem,
+    VivadoRunTreeItem,
 } from '../../views/projects-tree';
 
 // ── helpers ────────────────────────────────────────────────────────────────
+
+interface TestProjectsProvider<TProject> {
+    projects: TProject[];
+    listeners: Array<() => void>;
+    on(event: 'projectsChanged', listener: () => void): unknown;
+    getProjects(): Promise<TProject[]>;
+    emitProjectsChanged(): void;
+}
+
+type TestTreeNode<TChildren extends vscode.TreeItem[] = vscode.TreeItem[]> = vscode.TreeItem & {
+    getChildren(): Thenable<TChildren>;
+};
+
+function makeProjectsProvider<TProject>(projects: TProject[] = []): TestProjectsProvider<TProject> {
+    const provider: TestProjectsProvider<TProject> = {
+        projects,
+        listeners: [],
+        on: (_event, listener) => {
+            provider.listeners.push(listener);
+            return provider;
+        },
+        getProjects: async () => provider.projects,
+        emitProjectsChanged: () => provider.listeners.forEach(listener => listener()),
+    };
+
+    return provider;
+}
 
 function makeProject(name: string, files: HLSProjectFile[] = [], solutions: HLSProjectSolution[] = []): HLSProject {
     const uri = vscode.Uri.file(`/workspace/${name}/hls.app`);
@@ -26,6 +62,74 @@ function makeSourceFile(name: string): HLSProjectFile {
 
 function makeTestBenchFile(name: string): HLSProjectFile {
     return new HLSProjectFile(name, '0', true, '', '', false);
+}
+
+function makeVivadoProject(
+    name: string,
+    options: {
+        designSources?: string[];
+        simulationSources?: string[];
+        constraints?: string[];
+        runs?: VivadoRun[];
+        reports?: VivadoReport[];
+        part?: string;
+    } = {},
+): VivadoProject {
+    const root = vscode.Uri.file(`/workspace/${name}`);
+    const file = (filePath: string, kind: VivadoFileKind, filesetName: string) => new VivadoFile({
+        uri: vscode.Uri.file(`/workspace/${name}/${filePath}`),
+        kind,
+        filesetName,
+    });
+
+    return new VivadoProject({
+        name,
+        uri: root,
+        xprFile: vscode.Uri.file(`/workspace/${name}/${name}.xpr`),
+        part: options.part ?? 'xc7a35tcpg236-1',
+        topModule: 'top',
+        filesets: [
+            new VivadoFileset({
+                name: 'sources_1',
+                kind: VivadoFilesetKind.Sources,
+                files: (options.designSources ?? ['rtl/top.sv'])
+                    .map(filePath => file(filePath, VivadoFileKind.DesignSource, 'sources_1')),
+            }),
+            new VivadoFileset({
+                name: 'sim_1',
+                kind: VivadoFilesetKind.Simulation,
+                files: (options.simulationSources ?? ['sim/top_tb.sv'])
+                    .map(filePath => file(filePath, VivadoFileKind.SimulationSource, 'sim_1')),
+            }),
+            new VivadoFileset({
+                name: 'constrs_1',
+                kind: VivadoFilesetKind.Constraints,
+                files: (options.constraints ?? ['constraints/top.xdc'])
+                    .map(filePath => file(filePath, VivadoFileKind.Constraint, 'constrs_1')),
+            }),
+        ],
+        runs: options.runs ?? [
+            new VivadoRun({
+                name: 'synth_1',
+                type: VivadoRunType.Synthesis,
+                status: VivadoRunStatus.Complete,
+            }),
+            new VivadoRun({
+                name: 'impl_1',
+                type: VivadoRunType.Implementation,
+                status: VivadoRunStatus.Running,
+                parentRunName: 'synth_1',
+            }),
+        ],
+        reports: options.reports ?? [
+            new VivadoReport({
+                name: 'timing_summary.rpt',
+                uri: vscode.Uri.file(`/workspace/${name}/reports/timing_summary.rpt`),
+                kind: VivadoReportKind.Timing,
+                runName: 'impl_1',
+            }),
+        ],
+    });
 }
 
 // ── ProjectSourceItem ──────────────────────────────────────────────────────
@@ -174,9 +278,13 @@ suite('ProjectFileItem', () => {
 
 suite('ProjectsViewTreeProvider', () => {
     let provider: ProjectsViewTreeProvider;
+    let hlsProjectsProvider: TestProjectsProvider<HLSProject>;
+    let vivadoProjectsProvider: TestProjectsProvider<VivadoProject>;
 
     setup(() => {
-        provider = new ProjectsViewTreeProvider();
+        hlsProjectsProvider = makeProjectsProvider();
+        vivadoProjectsProvider = makeProjectsProvider();
+        provider = new ProjectsViewTreeProvider(hlsProjectsProvider, vivadoProjectsProvider);
     });
 
     teardown(() => {
@@ -197,10 +305,115 @@ suite('ProjectsViewTreeProvider', () => {
     });
 
     test('getChildren returns empty array when no projects are loaded', async () => {
-        // In the test environment there are no hls.app files, so the manager
-        // returns an empty project list.
         const children = await provider.getChildren();
         assert.strictEqual(children.length, 0);
+    });
+
+    test('renders Vivado projects separately from HLS projects', async () => {
+        hlsProjectsProvider.projects = [makeProject('demo')];
+        vivadoProjectsProvider.projects = [makeVivadoProject('demo')];
+
+        const children = await provider.getChildren();
+
+        assert.deepStrictEqual(children.map(child => child.label), ['demo', 'demo (Vivado)']);
+        assert.strictEqual(children[1].contextValue, 'vivadoProjectItem');
+    });
+
+    test('Vivado project children expose the minimal project structure', async () => {
+        vivadoProjectsProvider.projects = [makeVivadoProject('board')];
+        const [vivadoProject] = await provider.getChildren() as VivadoProjectTreeItem[];
+
+        const children = await vivadoProject.getChildren();
+
+        assert.deepStrictEqual(children.map(child => child.label), [
+            'Design Sources',
+            'Simulation Sources',
+            'Constraints',
+            'Runs',
+            'Reports',
+        ]);
+        assert.deepStrictEqual(children.map(child => child.contextValue), [
+            'vivadoDesignSourcesItem',
+            'vivadoSimulationSourcesItem',
+            'vivadoConstraintsItem',
+            'vivadoRunsItem',
+            'vivadoReportsItem',
+        ]);
+    });
+
+    test('Vivado file buckets return sorted openable files', async () => {
+        vivadoProjectsProvider.projects = [makeVivadoProject('board', {
+            designSources: ['rtl/z.sv', 'rtl/a.sv'],
+        })];
+        const [vivadoProject] = await provider.getChildren() as VivadoProjectTreeItem[];
+        const [designSources] = await vivadoProject.getChildren();
+        const files = await (designSources as TestTreeNode<VivadoProjectFileItem[]>).getChildren();
+
+        assert.deepStrictEqual(files.map(file => file.label), ['a.sv', 'z.sv']);
+        assert.strictEqual(files[0].contextValue, 'vivadoDesignSourceFileItem');
+        assert.strictEqual(files[0].command?.command, 'vscode.open');
+    });
+
+    test('Vivado runs and reports display model metadata', async () => {
+        vivadoProjectsProvider.projects = [makeVivadoProject('board')];
+        const [vivadoProject] = await provider.getChildren() as VivadoProjectTreeItem[];
+        const children = await vivadoProject.getChildren();
+
+        const runs = await (children[3] as TestTreeNode<VivadoRunTreeItem[]>).getChildren();
+        const reports = await (children[4] as TestTreeNode<VivadoReportTreeItem[]>).getChildren();
+
+        assert.deepStrictEqual(runs.map(run => run.label), ['synth_1', 'impl_1']);
+        assert.strictEqual(runs[0].description, 'synthesis: complete');
+        assert.strictEqual(runs[1].description, 'implementation: running');
+        assert.strictEqual(reports[0].label, 'timing_summary.rpt');
+        assert.strictEqual(reports[0].description, 'impl_1');
+        assert.strictEqual(reports[0].command?.command, 'vscode.open');
+    });
+
+    test('Vivado project and category nodes stay stable across refreshes', async () => {
+        vivadoProjectsProvider.projects = [makeVivadoProject('board', {
+            designSources: ['rtl/old_top.sv'],
+        })];
+        const [firstProject] = await provider.getChildren() as VivadoProjectTreeItem[];
+        const firstCategories = await firstProject.getChildren();
+
+        vivadoProjectsProvider.projects = [makeVivadoProject('board', {
+            designSources: ['rtl/new_top.sv'],
+        })];
+        const [secondProject] = await provider.getChildren() as VivadoProjectTreeItem[];
+        const secondCategories = await secondProject.getChildren();
+        const [secondDesignSources] = secondCategories;
+        const files = await (secondDesignSources as TestTreeNode<VivadoProjectFileItem[]>).getChildren();
+
+        assert.strictEqual(secondProject, firstProject);
+        assert.deepStrictEqual(secondCategories, firstCategories);
+        assert.deepStrictEqual(files.map(file => file.label), ['new_top.sv']);
+    });
+
+    test('empty Vivado categories degrade to empty children', async () => {
+        vivadoProjectsProvider.projects = [makeVivadoProject('empty', {
+            designSources: [],
+            simulationSources: [],
+            constraints: [],
+            runs: [],
+            reports: [],
+        })];
+        const [vivadoProject] = await provider.getChildren() as VivadoProjectTreeItem[];
+        const categories = await vivadoProject.getChildren();
+
+        for (const category of categories) {
+            const children = await (category as TestTreeNode).getChildren();
+            assert.strictEqual(children.length, 0);
+        }
+    });
+
+    test('fires tree changes when Vivado projects change', () => {
+        let fired = false;
+        provider.onDidChangeTreeData(() => { fired = true; });
+
+        vivadoProjectsProvider.emitProjectsChanged();
+
+        assert.strictEqual(fired, true);
     });
 
     test('onDidChangeTreeData is an event', () => {

--- a/src/views/projects-tree.ts
+++ b/src/views/projects-tree.ts
@@ -3,11 +3,21 @@ import * as vscode from 'vscode';
 import { HLSProject } from '../models/hls-project';
 import { HLSProjectFile } from '../models/hls-project-file';
 import { HLSProjectSolution } from '../models/hls-project-solution';
+import { VivadoFile } from '../models/vivado-file';
+import { VivadoProject } from '../models/vivado-project';
+import { VivadoReport } from '../models/vivado-report';
+import { VivadoRun, VivadoRunStatus, VivadoRunType } from '../models/vivado-run';
 import ProjectManager from '../project-manager';
+import VivadoProjectManager from '../vivado-project-manager';
 
 const startIconPath = new vscode.ThemeIcon('debug-start', new vscode.ThemeColor('debugIcon.startForeground'));
 const stopIconPath = new vscode.ThemeIcon('debug-stop', new vscode.ThemeColor('debugIcon.stopForeground'));
 const loadingIconPath = new vscode.ThemeIcon('loading~spin');
+
+interface ProjectsProvider<TProject> {
+    on(event: 'projectsChanged', listener: () => void): unknown;
+    getProjects(): Promise<TProject[]>;
+}
 
 class TreeItem extends vscode.TreeItem {
     constructor(label: string, collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.None) {
@@ -64,6 +74,184 @@ class ProjectTreeItem extends TreeItem {
             this._testBenchItem,
             ...this._solutionItems
         ]);
+    }
+}
+
+export class VivadoProjectTreeItem extends TreeItem {
+    public project: VivadoProject;
+
+    private readonly _designSourcesItem: VivadoFileCategoryItem;
+    private readonly _simulationSourcesItem: VivadoFileCategoryItem;
+    private readonly _constraintsItem: VivadoFileCategoryItem;
+    private readonly _runsItem: VivadoRunsItem;
+    private readonly _reportsItem: VivadoReportsItem;
+
+    constructor(project: VivadoProject) {
+        super(`${project.name} (Vivado)`, vscode.TreeItemCollapsibleState.Collapsed);
+        this.project = project;
+        this.contextValue = 'vivadoProjectItem';
+        this.iconPath = new vscode.ThemeIcon('circuit-board');
+
+        this._designSourcesItem = new VivadoFileCategoryItem(
+            'Design Sources',
+            'vivadoDesignSourcesItem',
+            'file-code',
+            'vivadoDesignSourceFileItem',
+            () => this.project.designSources,
+        );
+        this._simulationSourcesItem = new VivadoFileCategoryItem(
+            'Simulation Sources',
+            'vivadoSimulationSourcesItem',
+            'beaker',
+            'vivadoSimulationSourceFileItem',
+            () => this.project.simulationSources,
+        );
+        this._constraintsItem = new VivadoFileCategoryItem(
+            'Constraints',
+            'vivadoConstraintsItem',
+            'symbol-ruler',
+            'vivadoConstraintFileItem',
+            () => this.project.constraints,
+        );
+        this._runsItem = new VivadoRunsItem(() => this.project.runs);
+        this._reportsItem = new VivadoReportsItem(() => this.project.reports);
+
+        this.updateProject(project);
+    }
+
+    public updateProject(project: VivadoProject): void {
+        this.project = project;
+        this.label = `${project.name} (Vivado)`;
+        this.description = project.part;
+        this.tooltip = project.xprFile.fsPath;
+        this.resourceUri = project.xprFile;
+    }
+
+    public getChildren(): Thenable<TreeItem[]> {
+        return Promise.resolve([
+            this._designSourcesItem,
+            this._simulationSourcesItem,
+            this._constraintsItem,
+            this._runsItem,
+            this._reportsItem,
+        ]);
+    }
+}
+
+class VivadoFileCategoryItem extends TreeItem {
+    private readonly _getFiles: () => VivadoFile[];
+    private readonly _fileContextValue: string;
+
+    constructor(
+        label: string,
+        contextValue: string,
+        iconId: string,
+        fileContextValue: string,
+        getFiles: () => VivadoFile[],
+    ) {
+        super(label, vscode.TreeItemCollapsibleState.Collapsed);
+        this.contextValue = contextValue;
+        this.iconPath = new vscode.ThemeIcon(iconId);
+        this._getFiles = getFiles;
+        this._fileContextValue = fileContextValue;
+    }
+
+    public getChildren(): Thenable<VivadoProjectFileItem[]> {
+        return Promise.resolve(this._getFiles()
+            .slice()
+            .sort((a, b) => path.basename(a.uri.fsPath).localeCompare(path.basename(b.uri.fsPath)))
+            .map(file => new VivadoProjectFileItem(file, this._fileContextValue)));
+    }
+}
+
+export class VivadoProjectFileItem extends TreeItem {
+    public readonly file: VivadoFile;
+
+    constructor(file: VivadoFile, contextValue: string) {
+        super(path.basename(file.uri.fsPath));
+        this.file = file;
+        this.contextValue = contextValue;
+        this.resourceUri = file.uri;
+        this.description = file.filesetName;
+        this.iconPath = new vscode.ThemeIcon('file-code');
+        this.command = {
+            command: 'vscode.open',
+            title: 'Open File',
+            arguments: [file.uri],
+        };
+    }
+}
+
+class VivadoRunsItem extends TreeItem {
+    private readonly _getRuns: () => VivadoRun[];
+
+    constructor(getRuns: () => VivadoRun[]) {
+        super('Runs', vscode.TreeItemCollapsibleState.Collapsed);
+        this.contextValue = 'vivadoRunsItem';
+        this.iconPath = new vscode.ThemeIcon('run-all');
+        this._getRuns = getRuns;
+    }
+
+    public getChildren(): Thenable<VivadoRunTreeItem[]> {
+        return Promise.resolve(this._getRuns()
+            .slice()
+            .sort(compareVivadoRuns)
+            .map(run => new VivadoRunTreeItem(run)));
+    }
+}
+
+export class VivadoRunTreeItem extends TreeItem {
+    public readonly run: VivadoRun;
+
+    constructor(run: VivadoRun) {
+        super(run.name);
+        this.run = run;
+        this.contextValue = 'vivadoRunItem';
+        this.description = `${formatRunType(run.type)}: ${formatRunStatus(run.status)}`;
+        this.tooltip = [
+            `Run: ${run.name}`,
+            `Type: ${formatRunType(run.type)}`,
+            `Status: ${formatRunStatus(run.status)}`,
+            run.strategy ? `Strategy: ${run.strategy}` : undefined,
+            run.parentRunName ? `Parent: ${run.parentRunName}` : undefined,
+        ].filter((line): line is string => Boolean(line)).join('\n');
+        this.iconPath = iconForRunStatus(run.status);
+    }
+}
+
+class VivadoReportsItem extends TreeItem {
+    private readonly _getReports: () => VivadoReport[];
+
+    constructor(getReports: () => VivadoReport[]) {
+        super('Reports', vscode.TreeItemCollapsibleState.Collapsed);
+        this.contextValue = 'vivadoReportsItem';
+        this.iconPath = new vscode.ThemeIcon('graph');
+        this._getReports = getReports;
+    }
+
+    public getChildren(): Thenable<VivadoReportTreeItem[]> {
+        return Promise.resolve(this._getReports()
+            .slice()
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map(report => new VivadoReportTreeItem(report)));
+    }
+}
+
+export class VivadoReportTreeItem extends TreeItem {
+    public readonly report: VivadoReport;
+
+    constructor(report: VivadoReport) {
+        super(report.name);
+        this.report = report;
+        this.contextValue = 'vivadoReportItem';
+        this.description = report.runName ?? report.kind;
+        this.resourceUri = report.uri;
+        this.iconPath = new vscode.ThemeIcon('graph');
+        this.command = {
+            command: 'vscode.open',
+            title: 'Open Report',
+            arguments: [report.uri],
+        };
     }
 }
 
@@ -287,10 +475,20 @@ export default class ProjectsViewTreeProvider implements vscode.TreeDataProvider
     public readonly onDidChangeTreeData: vscode.Event<TreeItem | undefined | void> = this._onDidChangeTreeData.event;
 
     private _disposables: vscode.Disposable[] = [];
-    private readonly _children: ProjectTreeItem[] = [];
+    private readonly _hlsChildren: ProjectTreeItem[] = [];
+    private readonly _vivadoChildren: VivadoProjectTreeItem[] = [];
+    private readonly _hlsProjectManager: ProjectsProvider<HLSProject>;
+    private readonly _vivadoProjectManager: ProjectsProvider<VivadoProject>;
 
-    constructor() {
-        ProjectManager.instance.on('projectsChanged', () => this._onDidChangeTreeData.fire());
+    constructor(
+        hlsProjectManager: ProjectsProvider<HLSProject> = ProjectManager.instance,
+        vivadoProjectManager: ProjectsProvider<VivadoProject> = VivadoProjectManager.instance,
+    ) {
+        this._hlsProjectManager = hlsProjectManager;
+        this._vivadoProjectManager = vivadoProjectManager;
+
+        this._hlsProjectManager.on('projectsChanged', () => this._onDidChangeTreeData.fire());
+        this._vivadoProjectManager.on('projectsChanged', () => this._onDidChangeTreeData.fire());
         this._disposables = [
             vscode.tasks.onDidStartTask(() => this._onDidChangeTreeData.fire()),
             vscode.tasks.onDidEndTask(() => this._onDidChangeTreeData.fire()),
@@ -298,7 +496,7 @@ export default class ProjectsViewTreeProvider implements vscode.TreeDataProvider
         ];
     }
 
-    getTreeItem(element: ProjectTreeItem): vscode.TreeItem {
+    getTreeItem(element: TreeItem): vscode.TreeItem {
         return element;
     }
 
@@ -306,32 +504,120 @@ export default class ProjectsViewTreeProvider implements vscode.TreeDataProvider
         if (element) {
             return element.getChildren();
         } else {
-            const newProjects = await ProjectManager.instance.getProjects();
+            const [hlsProjects, vivadoProjects] = await Promise.all([
+                this._hlsProjectManager.getProjects(),
+                this._vivadoProjectManager.getProjects(),
+            ]);
 
-            // Add new projects
-            for (const project of newProjects) {
-                if (this._children.some(p => p.project.uri.toString() === project.uri.toString())) {
-                    continue; // Already exists
-                } else {
-                    this._children.push(new ProjectTreeItem(project));
-                }
-            }
+            this.syncHlsProjects(hlsProjects);
+            this.syncVivadoProjects(vivadoProjects);
 
-            // Remove projects that no longer exist
-            this._children.forEach(child => {
-                if (!newProjects.some(p => p.uri.toString() === child.project.uri.toString())) {
-                    this._children.splice(this._children.indexOf(child), 1);
-                }
-            });
-
-            this._children.sort((a, b) => a.project.name.localeCompare(b.project.name));
-
-            return this._children;
+            return [
+                ...this._hlsChildren,
+                ...this._vivadoChildren,
+            ];
         }
+    }
+
+    private syncHlsProjects(newProjects: HLSProject[]): void {
+        for (const project of newProjects) {
+            if (!this._hlsChildren.some(child => child.project.uri.toString() === project.uri.toString())) {
+                this._hlsChildren.push(new ProjectTreeItem(project));
+            }
+        }
+
+        for (let i = this._hlsChildren.length - 1; i >= 0; i--) {
+            if (!newProjects.some(project => project.uri.toString() === this._hlsChildren[i].project.uri.toString())) {
+                this._hlsChildren.splice(i, 1);
+            }
+        }
+
+        this._hlsChildren.sort((a, b) => a.project.name.localeCompare(b.project.name));
+    }
+
+    private syncVivadoProjects(newProjects: VivadoProject[]): void {
+        for (const project of newProjects) {
+            const existingChild = this._vivadoChildren.find(child => child.project.xprFile.toString() === project.xprFile.toString());
+
+            if (existingChild) {
+                existingChild.updateProject(project);
+            } else {
+                this._vivadoChildren.push(new VivadoProjectTreeItem(project));
+            }
+        }
+
+        for (let i = this._vivadoChildren.length - 1; i >= 0; i--) {
+            if (!newProjects.some(project => project.xprFile.toString() === this._vivadoChildren[i].project.xprFile.toString())) {
+                this._vivadoChildren.splice(i, 1);
+            }
+        }
+
+        this._vivadoChildren.sort((a, b) => a.project.name.localeCompare(b.project.name));
     }
 
     public dispose() {
         this._onDidChangeTreeData.dispose();
         this._disposables.forEach(d => d.dispose());
+    }
+}
+
+function compareVivadoRuns(a: VivadoRun, b: VivadoRun): number {
+    const typeComparison = runTypeOrder(a.type) - runTypeOrder(b.type);
+    return typeComparison === 0 ? a.name.localeCompare(b.name) : typeComparison;
+}
+
+function runTypeOrder(type: VivadoRunType): number {
+    switch (type) {
+        case VivadoRunType.Synthesis:
+            return 0;
+        case VivadoRunType.Implementation:
+            return 1;
+        case VivadoRunType.Simulation:
+            return 2;
+        default:
+            return 3;
+    }
+}
+
+function formatRunType(type: VivadoRunType): string {
+    switch (type) {
+        case VivadoRunType.Synthesis:
+            return 'synthesis';
+        case VivadoRunType.Implementation:
+            return 'implementation';
+        case VivadoRunType.Simulation:
+            return 'simulation';
+        default:
+            return 'other';
+    }
+}
+
+function formatRunStatus(status: VivadoRunStatus): string {
+    switch (status) {
+        case VivadoRunStatus.NotStarted:
+            return 'not started';
+        case VivadoRunStatus.Running:
+            return 'running';
+        case VivadoRunStatus.Complete:
+            return 'complete';
+        case VivadoRunStatus.Failed:
+            return 'failed';
+        default:
+            return 'unknown';
+    }
+}
+
+function iconForRunStatus(status: VivadoRunStatus): vscode.ThemeIcon {
+    switch (status) {
+        case VivadoRunStatus.Running:
+            return loadingIconPath;
+        case VivadoRunStatus.Complete:
+            return new vscode.ThemeIcon('check');
+        case VivadoRunStatus.Failed:
+            return new vscode.ThemeIcon('error');
+        case VivadoRunStatus.NotStarted:
+            return new vscode.ThemeIcon('circle-outline');
+        default:
+            return new vscode.ThemeIcon('question');
     }
 }


### PR DESCRIPTION
## Summary
- Render Vivado projects alongside existing HLS projects in the Projects tree.
- Add distinct Vivado tree nodes for Design Sources, Simulation Sources, Constraints, Runs, and Reports.
- Keep Vivado project/category nodes stable across refreshes while updating file/run/report children from the latest discovery model.
- Refresh both HLS and Vivado project managers from the existing project refresh command.

Closes #9

## Verification
- `npm test` (172 passing; includes compile and lint)
- `npm run docs:build`