### PR TITLE
feat: open Vivado projects in GUI

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -64,21 +64,48 @@ After the task ends, the extension reads the solution log and writes it to the V
 
 ### Refresh
 
-Use the refresh action in the Projects view title to rescan the workspace for `hls.app` files and reload project state.
+Use the refresh action in the Projects view title to rescan the workspace for
+`hls.app` and `.xpr` files and reload project state.
 
-## To-Be Vivado Features
+## Current Vivado Features
+
+### Vivado Project Discovery
+
+The extension activates for workspaces that contain `.xpr` files and discovers
+Vivado projects using `vscode-vivado.projectSearchGlobs`.
+
+### Vivado Project Tree
+
+Vivado projects render separately from HLS projects in the Projects tree. Each
+Vivado project contains:
+
+- `Design Sources`
+- `Simulation Sources`
+- `Constraints`
+- `Runs`
+- `Reports`
+
+Empty categories remain visible and expand to no children.
+
+### Open In Vivado
+
+Use the `Open in Vivado` context action on a Vivado project node to launch the
+Vivado IDE for that `.xpr` project. The command generates a visible TCL script
+that runs `open_project`, starts Vivado from the project directory, and uses the
+configured `vscode-vivado.vivadoPath`,
+`vscode-vivado.vivadoExecutablePath`, and
+`vscode-vivado.vivadoSettingsScript` settings.
+
+## Planned Vivado Features
 
 The extension should grow from HLS project management into Vivado project support. The desired Vivado features are listed here as the product target.
 
 For the implementation sequence and deeper feature plan, see the [Vivado Roadmap](roadmap.md).
 
-### Vivado Project Discovery
+### Expanded Source Tree
 
-Discover Vivado projects from `.xpr` files in the workspace. Each project should become a top-level tree item with enough metadata to show the project name, path, part, board, and active fileset.
-
-### Source Tree
-
-Show Vivado project contents in a tree that matches how FPGA engineers think about the project:
+Expand Vivado project contents in a tree that matches how FPGA engineers think
+about the project:
 
 - RTL design sources.
 - Simulation sources.
@@ -108,7 +135,9 @@ Parse Vivado messages from task output and report files. Diagnostics should link
 
 ### TCL Workflow
 
-Support project-based and script-based flows. Users should be able to run checked-in TCL scripts, generate project summaries, and inspect the exact commands issued by the extension.
+Support project-based and script-based flows. Users should be able to run
+checked-in TCL scripts, generate project summaries, and inspect the exact
+commands issued by the extension.
 
 ### HLS And Vivado Together
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,9 @@
 
 ## Project Status
 
-This repository is moving toward Vivado project support. The implementation currently activates around Vitis HLS project files, so the usage instructions are split into current behavior and intended Vivado behavior.
+This repository is moving toward full Vivado project support while preserving
+the inherited Vitis HLS workflow. The usage instructions are split into current
+HLS behavior and current Vivado behavior.
 
 ## Requirements
 
@@ -23,24 +25,24 @@ The extension activates when VS Code finds an `hls.app` file in the workspace.
 After activation, the Vitis HLS IDE activity bar view contains the Projects
 tree.
 
-## Target Vivado Workflow
+## Current Vivado Workflow
 
-The desired workflow is to open a VS Code workspace that contains one or more
+Open a VS Code workspace that contains one or more
 Vivado project files with the `.xpr` extension.
 
-The extension should then activate, discover Vivado projects, and show a Vivado-focused project tree with:
+The extension activates, discovers Vivado projects, and shows a Vivado-focused
+project tree with:
 
 - Design sources.
 - Simulation sources.
 - Constraint files.
-- IP and block design files.
-- Runs for synthesis, implementation, and bitstream generation.
-- Reports and generated artifacts.
+- Runs.
+- Reports.
 
-The extension now activates for `.xpr` workspaces and contributes Vivado
-settings. Vivado project discovery and tree behavior are still under
-development, so use the current Vitis HLS workflow for the project tree and run
-commands that exist today.
+Use the `Open in Vivado` context action on a Vivado project node to launch the
+Vivado IDE with that `.xpr` project. Synthesis, implementation, bitstream,
+simulation, IP, block design, and hardware-manager commands are still under
+development.
 
 ## Configure Tool Paths Today
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -64,8 +64,8 @@ Windows or `settings64.sh` on Linux.
 
 Default: empty string.
 
-Future Vivado task helpers can use this when Vivado is not already available on
-`PATH`.
+Vivado GUI and task helpers use this when Vivado is not already available on
+`PATH` or when the environment must be initialized before launch.
 
 ## `vscode-vivado.projectSearchGlobs`
 

--- a/package.json
+++ b/package.json
@@ -124,6 +124,11 @@
         "command": "vitis-hls-ide.projects.testbench.removeFile",
         "title": "Remove test bench file",
         "icon": "$(remove)"
+      },
+      {
+        "command": "vscode-vivado.projects.openInVivado",
+        "title": "Open in Vivado",
+        "icon": "$(open-preview)"
       }
     ],
     "viewsContainers": {
@@ -164,6 +169,10 @@
         {
           "command": "vitis-hls-ide.projects.testbench.removeFile",
           "when": "false"
+        },
+        {
+          "command": "vscode-vivado.projects.openInVivado",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -192,6 +201,11 @@
         {
           "command": "vitis-hls-ide.projects.testbench.removeFile",
           "when": "view == projectsView && viewItem == projectTestBenchFileItem",
+          "group": "inline"
+        },
+        {
+          "command": "vscode-vivado.projects.openInVivado",
+          "when": "view == projectsView && viewItem == vivadoProjectItem",
           "group": "inline"
         }
       ]

--- a/src/commands/vivado/open-project.ts
+++ b/src/commands/vivado/open-project.ts
@@ -1,0 +1,308 @@
+import { spawn, SpawnOptions } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import * as vscode from 'vscode';
+import { VivadoProject } from '../../models/vivado-project';
+import { OutputConsole } from '../../output-console';
+import { buildVivadoEnvironment } from '../../utils/vivado-run';
+import { getVivadoSettings, VivadoSettings } from '../../utils/vivado-settings';
+import {
+    buildVivadoTclFileUri,
+    resolveVivadoTclDirectory,
+    VivadoTclScript,
+    VivadoTclWriteOptions,
+    writeVisibleVivadoTclScript,
+} from '../../utils/vivado-tcl';
+
+const commandId = 'vscode-vivado.projects.openInVivado';
+
+export interface VivadoGuiLaunch {
+    command: string;
+    args: string[];
+    options: SpawnOptions;
+    commandLine: string;
+}
+
+export interface SpawnedVivadoProcess {
+    once(event: 'spawn', listener: () => void): this;
+    once(event: 'error', listener: (error: Error) => void): this;
+    unref(): void;
+}
+
+export type VivadoGuiSpawn = (command: string, args: string[], options: SpawnOptions) => SpawnedVivadoProcess;
+
+export interface OpenVivadoProjectDependencies {
+    existsSync: (filePath: string) => boolean;
+    spawn: VivadoGuiSpawn;
+    writeTclScript: (options: VivadoTclWriteOptions) => VivadoTclScript;
+    showErrorMessage: (message: string) => Thenable<string | undefined>;
+    appendLine: (message: string) => void;
+    environment: NodeJS.ProcessEnv;
+    shell?: string;
+}
+
+export interface OpenVivadoProjectOptions {
+    settings?: VivadoSettings;
+    platform?: NodeJS.Platform;
+    now?: Date;
+    tclDirectory?: vscode.Uri;
+    dependencies?: Partial<OpenVivadoProjectDependencies>;
+}
+
+export default async function openVivadoProject(
+    project: VivadoProject | undefined,
+    options: OpenVivadoProjectOptions = {},
+): Promise<boolean> {
+    const platform = options.platform ?? process.platform;
+    const settings = options.settings ?? getVivadoSettings({ platform });
+    const dependencies = resolveDependencies(options.dependencies);
+
+    try {
+        if (!project) {
+            throw new Error('Select a Vivado project in the Projects view before running Open in Vivado.');
+        }
+
+        const environment = buildVivadoEnvironment(settings, dependencies.environment, platform);
+        validateVivadoProject(project, dependencies.existsSync);
+        validateVivadoLaunchSettings(settings, platform, environment, dependencies.existsSync);
+
+        const taskName = `Open ${project.name} in Vivado`;
+        const tclDirectory = options.tclDirectory ?? resolveVivadoTclDirectory(project.uri, settings);
+        const tclFile = buildVivadoTclFileUri(tclDirectory, taskName, options.now);
+        const launch = buildVivadoGuiLaunch(project, tclFile, settings, {
+            environment,
+            platform,
+            shell: dependencies.shell,
+        });
+        const script = dependencies.writeTclScript({
+            startPath: project.uri,
+            taskName,
+            tcl: buildVivadoOpenProjectTcl(project),
+            settings,
+            rerunCommand: launch.commandLine,
+            tclDirectory,
+            uri: tclFile,
+            now: options.now,
+        });
+
+        dependencies.appendLine(`Vivado GUI TCL script: ${script.uri.fsPath}`);
+        dependencies.appendLine(`Launch Vivado GUI: ${launch.commandLine}`);
+
+        await launchVivadoGui(launch, dependencies.spawn);
+        return true;
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        await dependencies.showErrorMessage(message);
+        return false;
+    }
+}
+
+export function buildVivadoOpenProjectTcl(project: VivadoProject): string {
+    return `open_project ${quoteTclString(project.xprFile.fsPath)}`;
+}
+
+export function buildVivadoGuiLaunch(
+    project: VivadoProject,
+    tclFile: vscode.Uri,
+    settings: VivadoSettings,
+    options: {
+        environment?: NodeJS.ProcessEnv;
+        platform?: NodeJS.Platform;
+        shell?: string;
+    } = {},
+): VivadoGuiLaunch {
+    const platform = options.platform ?? process.platform;
+    const environment = options.environment ?? buildVivadoEnvironment(settings, process.env, platform);
+    const vivadoCommand = [
+        quoteShellArgument(settings.resolvedExecutablePath, platform),
+        '-mode',
+        'gui',
+        '-source',
+        quoteShellArgument(tclFile.fsPath, platform),
+    ].join(' ');
+
+    if (platform === 'win32') {
+        const commandBody = settings.vivadoSettingsScript
+            ? `call ${quoteShellArgument(settings.vivadoSettingsScript, platform)} && ${vivadoCommand}`
+            : vivadoCommand;
+
+        return {
+            command: 'cmd.exe',
+            args: ['/d', '/c', commandBody],
+            options: buildSpawnOptions(project, environment),
+            commandLine: `cmd.exe /d /c ${quoteWindowsCommand(commandBody)}`,
+        };
+    }
+
+    if (settings.vivadoSettingsScript) {
+        const shell = options.shell ?? process.env.SHELL ?? '/bin/sh';
+        const commandBody = `. ${quoteShellArgument(settings.vivadoSettingsScript, platform)} && ${vivadoCommand}`;
+
+        return {
+            command: shell,
+            args: ['-c', commandBody],
+            options: buildSpawnOptions(project, environment),
+            commandLine: `${quoteShellArgument(shell, platform)} -c ${quoteShellArgument(commandBody, platform)}`,
+        };
+    }
+
+    return {
+        command: settings.resolvedExecutablePath,
+        args: ['-mode', 'gui', '-source', tclFile.fsPath],
+        options: buildSpawnOptions(project, environment),
+        commandLine: vivadoCommand,
+    };
+}
+
+function resolveDependencies(dependencies: Partial<OpenVivadoProjectDependencies> = {}): OpenVivadoProjectDependencies {
+    return {
+        existsSync: fs.existsSync,
+        spawn: (command, args, options) => spawn(command, args, options) as SpawnedVivadoProcess,
+        writeTclScript: writeVisibleVivadoTclScript,
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        appendLine: message => OutputConsole.instance.appendLine(message),
+        environment: process.env,
+        ...dependencies,
+    };
+}
+
+function validateVivadoProject(project: VivadoProject, existsSync: (filePath: string) => boolean): void {
+    if (path.extname(project.xprFile.fsPath).toLowerCase() !== '.xpr') {
+        throw new Error(`Vivado project path is not a .xpr file: ${project.xprFile.fsPath}`);
+    }
+
+    if (!existsSync(project.xprFile.fsPath)) {
+        throw new Error(`Vivado project file not found: ${project.xprFile.fsPath}`);
+    }
+}
+
+function validateVivadoLaunchSettings(
+    settings: VivadoSettings,
+    platform: NodeJS.Platform,
+    environment: NodeJS.ProcessEnv,
+    existsSync: (filePath: string) => boolean,
+): void {
+    if (settings.vivadoSettingsScript && !existsSync(settings.vivadoSettingsScript)) {
+        throw new Error(`Vivado settings script not found: ${settings.vivadoSettingsScript}`);
+    }
+
+    if (looksLikePath(settings.resolvedExecutablePath, platform)) {
+        if (!existsSync(settings.resolvedExecutablePath)) {
+            throw new Error(
+                `Vivado executable not found: ${settings.resolvedExecutablePath}. ` +
+                'Set vscode-vivado.vivadoPath or vscode-vivado.vivadoExecutablePath.',
+            );
+        }
+        return;
+    }
+
+    if (!commandExistsOnPath(settings.resolvedExecutablePath, environment, platform, existsSync)) {
+        throw new Error(
+            `Vivado executable not found on PATH: ${settings.resolvedExecutablePath}. ` +
+            'Set vscode-vivado.vivadoPath or vscode-vivado.vivadoExecutablePath.',
+        );
+    }
+}
+
+function buildSpawnOptions(project: VivadoProject, environment: NodeJS.ProcessEnv): SpawnOptions {
+    return {
+        cwd: project.uri.fsPath,
+        detached: true,
+        env: environment,
+        stdio: 'ignore',
+        windowsHide: false,
+    };
+}
+
+function launchVivadoGui(launch: VivadoGuiLaunch, spawnProcess: VivadoGuiSpawn): Promise<void> {
+    return new Promise((resolve, reject) => {
+        let child: SpawnedVivadoProcess;
+        let settled = false;
+
+        try {
+            child = spawnProcess(launch.command, launch.args, launch.options);
+        } catch (error) {
+            reject(new Error(`Failed to launch Vivado: ${error instanceof Error ? error.message : String(error)}`));
+            return;
+        }
+
+        child.once('error', error => {
+            if (!settled) {
+                settled = true;
+                reject(new Error(`Failed to launch Vivado: ${error.message}`));
+            }
+        });
+
+        child.once('spawn', () => {
+            if (!settled) {
+                settled = true;
+                child.unref();
+                resolve();
+            }
+        });
+    });
+}
+
+function commandExistsOnPath(
+    command: string,
+    environment: NodeJS.ProcessEnv,
+    platform: NodeJS.Platform,
+    existsSync: (filePath: string) => boolean,
+): boolean {
+    const pathKey = Object.keys(environment).find(key => key.toLowerCase() === 'path') ?? 'PATH';
+    const pathValue = environment[pathKey] ?? '';
+    const pathDelimiter = platform === 'win32' ? ';' : ':';
+    const pathApi = getPathApi(platform);
+    const extensions = getExecutableExtensions(command, environment, platform);
+
+    return pathValue
+        .split(pathDelimiter)
+        .filter(directory => directory.length > 0)
+        .some(directory => extensions.some(extension => existsSync(pathApi.join(directory, `${command}${extension}`))));
+}
+
+function getExecutableExtensions(command: string, environment: NodeJS.ProcessEnv, platform: NodeJS.Platform): string[] {
+    if (platform !== 'win32' || path.win32.extname(command)) {
+        return [''];
+    }
+
+    const pathextKey = Object.keys(environment).find(key => key.toLowerCase() === 'pathext');
+    const pathext = pathextKey ? environment[pathextKey] ?? '' : '.COM;.EXE;.BAT;.CMD';
+    return [
+        ...pathext.split(';').filter(extension => extension.length > 0),
+        '',
+    ];
+}
+
+function quoteTclString(value: string): string {
+    return `"${value
+        .replace(/\\/g, '\\\\')
+        .replace(/\$/g, '\\$')
+        .replace(/"/g, '\\"')
+        .replace(/\[/g, '\\[')
+        .replace(/\]/g, '\\]')
+        .replace(/\r/g, '\\r')
+        .replace(/\n/g, '\\n')}"`;
+}
+
+function quoteShellArgument(value: string, platform: NodeJS.Platform): string {
+    if (platform === 'win32') {
+        return `"${value.replace(/"/g, '""')}"`;
+    }
+
+    return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function quoteWindowsCommand(value: string): string {
+    return `"${value}"`;
+}
+
+function looksLikePath(value: string, platform: NodeJS.Platform): boolean {
+    return value.includes('/') || value.includes('\\') || getPathApi(platform).isAbsolute(value);
+}
+
+function getPathApi(platform: NodeJS.Platform): path.PlatformPath {
+    return platform === 'win32' ? path.win32 : path.posix;
+}
+
+export { commandId as openVivadoProjectCommandId };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,10 +8,11 @@ import runCsynth from './commands/project/run/projects-run-csynth';
 import stopCosim from './commands/project/run/projects-stop-cosim';
 import stopCsim from './commands/project/run/projects-stop-csim';
 import stopCsynth from './commands/project/run/projects-stop-csynth';
+import openVivadoProject, { openVivadoProjectCommandId } from './commands/vivado/open-project';
 import { OutputConsole } from './output-console';
 import ProjectManager from './project-manager';
 import VivadoProjectManager from './vivado-project-manager';
-import ProjectsViewTreeProvider, { ProjectFileItem, ProjectSourceItem, ProjectTestBenchItem } from './views/projects-tree';
+import ProjectsViewTreeProvider, { ProjectFileItem, ProjectSourceItem, ProjectTestBenchItem, VivadoProjectTreeItem } from './views/projects-tree';
 
 // TODO Make Vitis Unified IDE optional
 // TODO Proper feedback to let ppl know they don't have Vitis Unified IDE
@@ -41,6 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('vitis-hls-ide.projects.source.removeFile', (e: ProjectFileItem) => removeFile(e.project, e.resourceUri!, false)),
 		vscode.commands.registerCommand('vitis-hls-ide.projects.testbench.addFiles', (e: ProjectTestBenchItem) => addFiles(e.project, true)),
 		vscode.commands.registerCommand('vitis-hls-ide.projects.testbench.removeFile', (e: ProjectFileItem) => removeFile(e.project, e.resourceUri!, true)),
+		vscode.commands.registerCommand(openVivadoProjectCommandId, (e?: VivadoProjectTreeItem) => openVivadoProject(e?.project)),
 		projectsViewProvider,
 		OutputConsole.instance,
 		ProjectManager.instance,

--- a/src/test/commands/vivado-open-project.test.ts
+++ b/src/test/commands/vivado-open-project.test.ts
@@ -57,10 +57,11 @@ suite('Vivado open project command construction', () => {
             uri: vscode.Uri.file('C:/workspace/demo'),
             xprFile: vscode.Uri.file('C:/workspace/demo/demo.xpr'),
         });
+        const escapedPath = project.xprFile.fsPath.replace(/\\/g, '\\\\');
 
         assert.strictEqual(
             buildVivadoOpenProjectTcl(project),
-            'open_project "c:\\\\workspace\\\\demo\\\\demo.xpr"',
+            `open_project "${escapedPath}"`,
         );
     });
 

--- a/src/test/commands/vivado-open-project.test.ts
+++ b/src/test/commands/vivado-open-project.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for opening Vivado projects in the Vivado GUI.
+ * Covers #10 - Add command to open a Vivado project in the GUI.
+ */
+import { EventEmitter } from 'events';
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoSettings } from '../../utils/vivado-settings';
+import {
+    buildVivadoGuiLaunch,
+    buildVivadoOpenProjectTcl,
+    openVivadoProjectCommandId,
+    SpawnedVivadoProcess,
+    VivadoGuiLaunch,
+    VivadoGuiSpawn,
+} from '../../commands/vivado/open-project';
+import openVivadoProject from '../../commands/vivado/open-project';
+
+function makeSettings(overrides: Partial<VivadoSettings> = {}): VivadoSettings {
+    return {
+        vivadoPath: '/tools/vivado',
+        vivadoExecutablePath: '',
+        vivadoSettingsScript: '',
+        projectSearchGlobs: ['**/*.xpr'],
+        reportsDirectory: 'reports',
+        generatedTclDirectory: '.vscode-vivado/tcl',
+        preserveRunLogs: true,
+        resolvedExecutablePath: '/tools/vivado/bin/vivado',
+        pathEntries: ['/tools/vivado/bin'],
+        ...overrides,
+    };
+}
+
+function makeProject(name: string = 'demo'): VivadoProject {
+    return new VivadoProject({
+        name,
+        uri: vscode.Uri.file(`/workspace/${name}`),
+        xprFile: vscode.Uri.file(`/workspace/${name}/${name}.xpr`),
+    });
+}
+
+function makeFakeProcess(): SpawnedVivadoProcess & EventEmitter & { unrefCalled: boolean } {
+    const process = new EventEmitter() as SpawnedVivadoProcess & EventEmitter & { unrefCalled: boolean };
+    process.unrefCalled = false;
+    process.unref = () => {
+        process.unrefCalled = true;
+    };
+    return process;
+}
+
+suite('Vivado open project command construction', () => {
+    test('builds TCL that opens the selected .xpr project', () => {
+        const project = new VivadoProject({
+            name: 'demo',
+            uri: vscode.Uri.file('C:/workspace/demo'),
+            xprFile: vscode.Uri.file('C:/workspace/demo/demo.xpr'),
+        });
+
+        assert.strictEqual(
+            buildVivadoOpenProjectTcl(project),
+            'open_project "c:\\\\workspace\\\\demo\\\\demo.xpr"',
+        );
+    });
+
+    test('builds a Windows GUI launch through cmd.exe for batch executables', () => {
+        const project = makeProject();
+        const launch = buildVivadoGuiLaunch(
+            project,
+            vscode.Uri.file('C:/workspace/demo/.vscode-vivado/tcl/open.tcl'),
+            makeSettings({
+                vivadoSettingsScript: 'C:\\Xilinx\\Vivado\\2023.2\\settings64.bat',
+                resolvedExecutablePath: 'C:\\Xilinx\\Vivado\\2023.2\\bin\\vivado.bat',
+                pathEntries: ['C:\\Xilinx\\Vivado\\2023.2\\bin'],
+            }),
+            {
+                platform: 'win32',
+                environment: { Path: 'C:\\Windows\\System32' },
+            },
+        );
+
+        assert.strictEqual(launch.command, 'cmd.exe');
+        assert.deepStrictEqual(launch.args.slice(0, 2), ['/d', '/c']);
+        assert.ok(launch.args[2].includes('call "C:\\Xilinx\\Vivado\\2023.2\\settings64.bat"'));
+        assert.ok(launch.args[2].includes('"C:\\Xilinx\\Vivado\\2023.2\\bin\\vivado.bat" -mode gui -source'));
+        assert.strictEqual(launch.options.cwd, project.uri.fsPath);
+        assert.strictEqual(launch.options.detached, true);
+    });
+});
+
+suite('openVivadoProject', () => {
+    test('writes visible TCL and launches Vivado from the project directory', async () => {
+        const project = makeProject();
+        const spawnedProcess = makeFakeProcess();
+        const spawnCalls: Array<Pick<VivadoGuiLaunch, 'command' | 'args' | 'options'>> = [];
+        let writtenTcl = '';
+        let shownError: string | undefined;
+
+        const spawnVivado: VivadoGuiSpawn = (command, args, options) => {
+            spawnCalls.push({ command, args, options });
+            setImmediate(() => spawnedProcess.emit('spawn'));
+            return spawnedProcess;
+        };
+
+        const result = await openVivadoProject(project, {
+            settings: makeSettings(),
+            platform: 'linux',
+            now: new Date('2026-04-19T00:00:00Z'),
+            dependencies: {
+                environment: { PATH: '/usr/bin' },
+                existsSync: filePath => [
+                    project.xprFile.fsPath,
+                    '/tools/vivado/bin/vivado',
+                ].includes(filePath),
+                spawn: spawnVivado,
+                writeTclScript: options => {
+                    writtenTcl = options.tcl;
+                    return { uri: options.uri!, content: options.tcl };
+                },
+                showErrorMessage: async message => {
+                    shownError = message;
+                    return undefined;
+                },
+                appendLine: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, true);
+        assert.strictEqual(shownError, undefined);
+        assert.strictEqual(writtenTcl, buildVivadoOpenProjectTcl(project));
+        assert.strictEqual(spawnCalls.length, 1);
+        assert.strictEqual(spawnCalls[0].command, '/tools/vivado/bin/vivado');
+        assert.deepStrictEqual(spawnCalls[0].args.slice(0, 3), ['-mode', 'gui', '-source']);
+        assert.strictEqual(spawnCalls[0].options.cwd, project.uri.fsPath);
+        assert.strictEqual((spawnCalls[0].options.env as NodeJS.ProcessEnv).PATH, '/tools/vivado/bin:/usr/bin');
+        assert.strictEqual(spawnedProcess.unrefCalled, true);
+    });
+
+    test('shows an actionable error when the project file is missing', async () => {
+        const project = makeProject();
+        let shownError = '';
+        let spawnCalled = false;
+
+        const result = await openVivadoProject(project, {
+            settings: makeSettings(),
+            platform: 'linux',
+            dependencies: {
+                existsSync: () => false,
+                spawn: () => {
+                    spawnCalled = true;
+                    return makeFakeProcess();
+                },
+                showErrorMessage: async message => {
+                    shownError = message;
+                    return undefined;
+                },
+                appendLine: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(spawnCalled, false);
+        assert.ok(shownError.includes('Vivado project file not found'));
+        assert.ok(shownError.includes(project.xprFile.fsPath));
+    });
+
+    test('shows an actionable error when the Vivado executable is missing', async () => {
+        const project = makeProject();
+        let shownError = '';
+        let spawnCalled = false;
+
+        const result = await openVivadoProject(project, {
+            settings: makeSettings({
+                resolvedExecutablePath: '/missing/vivado/bin/vivado',
+                pathEntries: ['/missing/vivado/bin'],
+            }),
+            platform: 'linux',
+            dependencies: {
+                existsSync: filePath => filePath === project.xprFile.fsPath,
+                spawn: () => {
+                    spawnCalled = true;
+                    return makeFakeProcess();
+                },
+                showErrorMessage: async message => {
+                    shownError = message;
+                    return undefined;
+                },
+                appendLine: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(spawnCalled, false);
+        assert.ok(shownError.includes('Vivado executable not found'));
+        assert.ok(shownError.includes('vscode-vivado.vivadoPath'));
+    });
+
+    test('shows an actionable error when Vivado cannot be spawned', async () => {
+        const project = makeProject();
+        const spawnedProcess = makeFakeProcess();
+        let shownError = '';
+
+        const result = await openVivadoProject(project, {
+            settings: makeSettings(),
+            platform: 'linux',
+            dependencies: {
+                environment: { PATH: '/usr/bin' },
+                existsSync: filePath => [
+                    project.xprFile.fsPath,
+                    '/tools/vivado/bin/vivado',
+                ].includes(filePath),
+                spawn: () => {
+                    setImmediate(() => spawnedProcess.emit('error', new Error('ENOENT')));
+                    return spawnedProcess;
+                },
+                writeTclScript: options => ({ uri: options.uri!, content: options.tcl }),
+                showErrorMessage: async message => {
+                    shownError = message;
+                    return undefined;
+                },
+                appendLine: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.ok(shownError.includes('Failed to launch Vivado: ENOENT'));
+    });
+});
+
+suite('Vivado open project package contribution', () => {
+    test('contributes the Open in Vivado command only to Vivado project tree items', () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const pkg = require('../../../package.json');
+        const command = pkg.contributes.commands.find((entry: { command: string }) => entry.command === openVivadoProjectCommandId);
+        const paletteEntry = pkg.contributes.menus.commandPalette.find((entry: { command: string }) => entry.command === openVivadoProjectCommandId);
+        const contextEntry = pkg.contributes.menus['view/item/context'].find((entry: { command: string }) => entry.command === openVivadoProjectCommandId);
+
+        assert.strictEqual(command.title, 'Open in Vivado');
+        assert.strictEqual(paletteEntry.when, 'false');
+        assert.strictEqual(contextEntry.when, 'view == projectsView && viewItem == vivadoProjectItem');
+    });
+});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -5,6 +5,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as ext from '../extension';
+import { openVivadoProjectCommandId } from '../commands/vivado/open-project';
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -104,6 +105,31 @@ suite('Extension activation', () => {
 
     test('deactivate does not throw', () => {
         assert.doesNotThrow(() => ext.deactivate());
+    });
+
+    test('registers the Vivado open project command', async () => {
+        const fakeContext = makeFakeContext();
+        const registeredCommands: string[] = [];
+        const origRegisterCommand = vscode.commands.registerCommand.bind(vscode.commands);
+        (vscode.commands as any).registerCommand = (id: string, _handler: (...args: any[]) => any) => {
+            registeredCommands.push(id);
+            return { dispose: () => { /* no-op */ } };
+        };
+
+        try {
+            await withStub(
+                vscode.window as any,
+                'showWarningMessage',
+                async () => undefined,
+                async () => {
+                    ext.activate(fakeContext);
+                }
+            );
+        } finally {
+            (vscode.commands as any).registerCommand = origRegisterCommand;
+        }
+
+        assert.ok(registeredCommands.includes(openVivadoProjectCommandId));
     });
 });
 


### PR DESCRIPTION
## Summary
- Add an `Open in Vivado` context action for Vivado project tree nodes.
- Generate visible `open_project` TCL and launch Vivado in GUI mode from the selected project directory.
- Validate missing `.xpr`, executable, settings-script, and launch failures with actionable errors.
- Document the current Vivado discovery/tree/open workflow.

Closes #10

## Verification
- `npm test` (180 passing; includes compile and lint)
- `npm run docs:build`