### PR TITLE
feat: add Vivado synthesis command

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -96,6 +96,13 @@ configured `vscode-vivado.vivadoPath`,
 `vscode-vivado.vivadoExecutablePath`, and
 `vscode-vivado.vivadoSettingsScript` settings.
 
+### Run Synthesis
+
+Use the `Run Synthesis` context action on a Vivado project node or synthesis run
+node to launch the selected project-mode synthesis run as a VS Code task. The
+command generates visible TCL that opens the `.xpr`, calls `launch_runs`, waits
+for the run, and checks that Vivado reports `PROGRESS` as `100%`.
+
 ## Planned Vivado Features
 
 The extension should grow from HLS project management into Vivado project support. The desired Vivado features are listed here as the product target.
@@ -122,7 +129,6 @@ Expose common Vivado runs as VS Code commands and tasks:
 
 - Elaborate design.
 - Run behavioral simulation.
-- Run synthesis.
 - Run implementation.
 - Generate bitstream.
 - Open timing, utilization, DRC, and power reports.

--- a/package.json
+++ b/package.json
@@ -129,6 +129,11 @@
         "command": "vscode-vivado.projects.openInVivado",
         "title": "Open in Vivado",
         "icon": "$(open-preview)"
+      },
+      {
+        "command": "vscode-vivado.projects.runSynthesis",
+        "title": "Run Synthesis",
+        "icon": "$(debug-start)"
       }
     ],
     "viewsContainers": {
@@ -173,6 +178,10 @@
         {
           "command": "vscode-vivado.projects.openInVivado",
           "when": "false"
+        },
+        {
+          "command": "vscode-vivado.projects.runSynthesis",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -206,6 +215,16 @@
         {
           "command": "vscode-vivado.projects.openInVivado",
           "when": "view == projectsView && viewItem == vivadoProjectItem",
+          "group": "inline"
+        },
+        {
+          "command": "vscode-vivado.projects.runSynthesis",
+          "when": "view == projectsView && viewItem == vivadoProjectItem",
+          "group": "inline@1"
+        },
+        {
+          "command": "vscode-vivado.projects.runSynthesis",
+          "when": "view == projectsView && viewItem == vivadoSynthesisRunItem",
           "group": "inline"
         }
       ]

--- a/src/commands/vivado/open-project.ts
+++ b/src/commands/vivado/open-project.ts
@@ -8,6 +8,7 @@ import { buildVivadoEnvironment } from '../../utils/vivado-run';
 import { getVivadoSettings, VivadoSettings } from '../../utils/vivado-settings';
 import {
     buildVivadoTclFileUri,
+    quoteTclString,
     resolveVivadoTclDirectory,
     VivadoTclScript,
     VivadoTclWriteOptions,
@@ -272,17 +273,6 @@ function getExecutableExtensions(command: string, environment: NodeJS.ProcessEnv
         ...pathext.split(';').filter(extension => extension.length > 0),
         '',
     ];
-}
-
-function quoteTclString(value: string): string {
-    return `"${value
-        .replace(/\\/g, '\\\\')
-        .replace(/\$/g, '\\$')
-        .replace(/"/g, '\\"')
-        .replace(/\[/g, '\\[')
-        .replace(/\]/g, '\\]')
-        .replace(/\r/g, '\\r')
-        .replace(/\n/g, '\\n')}"`;
 }
 
 function quoteShellArgument(value: string, platform: NodeJS.Platform): string {

--- a/src/commands/vivado/run-synthesis.ts
+++ b/src/commands/vivado/run-synthesis.ts
@@ -1,0 +1,160 @@
+import * as vscode from 'vscode';
+import { vivadoTaskSource } from '../../constants';
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoRun, VivadoRunType } from '../../models/vivado-run';
+import VivadoProjectManager from '../../vivado-project-manager';
+import { vivadoRun, VivadoRunOptions } from '../../utils/vivado-run';
+import { quoteTclString } from '../../utils/vivado-tcl';
+
+const commandId = 'vscode-vivado.projects.runSynthesis';
+
+export interface VivadoRunCommandTarget {
+    project?: VivadoProject;
+    run?: VivadoRun;
+}
+
+export interface RunVivadoSynthesisDependencies {
+    vivadoRun: (startPath: vscode.Uri, tcl: string, taskName: string, options?: VivadoRunOptions) => Promise<number | undefined>;
+    showErrorMessage: (message: string) => Thenable<string | undefined>;
+    showInformationMessage: (message: string) => Thenable<string | undefined>;
+    getTaskExecutions: () => readonly vscode.TaskExecution[];
+    refreshVivadoProjects: () => void | Promise<void>;
+}
+
+export interface RunVivadoSynthesisOptions {
+    dependencies?: Partial<RunVivadoSynthesisDependencies>;
+}
+
+interface ResolvedVivadoRunCommand {
+    project: VivadoProject;
+    run: VivadoRun;
+}
+
+export default async function runVivadoSynthesis(
+    target: VivadoProject | VivadoRunCommandTarget | undefined,
+    options: RunVivadoSynthesisOptions = {},
+): Promise<boolean> {
+    const dependencies = resolveDependencies(options.dependencies);
+
+    try {
+        const { project, run } = resolveSynthesisTarget(target);
+        ensureNoActiveVivadoTask(dependencies.getTaskExecutions());
+
+        const taskName = buildVivadoSynthesisTaskName(project, run);
+        const exitCode = await dependencies.vivadoRun(
+            project.uri,
+            buildVivadoSynthesisTcl(project, run),
+            taskName,
+            {
+                presentationOptions: {
+                    reveal: vscode.TaskRevealKind.Always,
+                    panel: vscode.TaskPanelKind.Shared,
+                    clear: false,
+                },
+            },
+        );
+
+        if (exitCode === 0) {
+            await dependencies.showInformationMessage(`Vivado synthesis completed for ${project.name}/${run.name}.`);
+            await dependencies.refreshVivadoProjects();
+            return true;
+        }
+
+        if (exitCode === undefined) {
+            return false;
+        }
+
+        await dependencies.showErrorMessage(
+            `Vivado synthesis failed for ${project.name}/${run.name}. Review the Vivado task output and generated TCL script.`,
+        );
+        return false;
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        await dependencies.showErrorMessage(message);
+        return false;
+    }
+}
+
+export function buildVivadoSynthesisTcl(project: VivadoProject, run: VivadoRun): string {
+    const projectPath = quoteTclString(project.xprFile.fsPath);
+    const runName = quoteTclString(run.name);
+
+    return [
+        `open_project ${projectPath}`,
+        `launch_runs ${runName}`,
+        `wait_on_run ${runName}`,
+        `if {[get_property PROGRESS [get_runs ${runName}]] != "100%"} {`,
+        `    error ${quoteTclString(`Synthesis run ${run.name} did not complete`)}`,
+        '}',
+        'close_project',
+    ].join('\n');
+}
+
+export function buildVivadoSynthesisTaskName(project: VivadoProject, run: VivadoRun): string {
+    return `Vivado: Synthesis ${project.name}/${run.name}`;
+}
+
+export function resolveSynthesisTarget(target: VivadoProject | VivadoRunCommandTarget | undefined): ResolvedVivadoRunCommand {
+    if (!target) {
+        throw new Error('Select a Vivado project or synthesis run in the Projects view before running synthesis.');
+    }
+
+    if (target instanceof VivadoProject) {
+        return {
+            project: target,
+            run: chooseDefaultSynthesisRun(target),
+        };
+    }
+
+    if (!(target.project instanceof VivadoProject)) {
+        throw new Error('Select a Vivado project or synthesis run in the Projects view before running synthesis.');
+    }
+
+    if (!target.run) {
+        return {
+            project: target.project,
+            run: chooseDefaultSynthesisRun(target.project),
+        };
+    }
+
+    if (!(target.run instanceof VivadoRun) || target.run.type !== VivadoRunType.Synthesis) {
+        throw new Error('Select a synthesis run or Vivado project before running synthesis.');
+    }
+
+    return {
+        project: target.project,
+        run: target.run,
+    };
+}
+
+function chooseDefaultSynthesisRun(project: VivadoProject): VivadoRun {
+    const synthesisRuns = project.runsByType(VivadoRunType.Synthesis)
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name));
+    const run = synthesisRuns.find(candidate => candidate.name === 'synth_1') ?? synthesisRuns[0];
+
+    if (!run) {
+        throw new Error(`Vivado project ${project.name} has no synthesis runs.`);
+    }
+
+    return run;
+}
+
+function ensureNoActiveVivadoTask(taskExecutions: readonly vscode.TaskExecution[]): void {
+    if (taskExecutions.some(execution => execution.task.source === vivadoTaskSource)) {
+        throw new Error('A Vivado task is already running. Wait for it to finish before starting synthesis.');
+    }
+}
+
+function resolveDependencies(dependencies: Partial<RunVivadoSynthesisDependencies> = {}): RunVivadoSynthesisDependencies {
+    return {
+        vivadoRun,
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        showInformationMessage: message => vscode.window.showInformationMessage(message),
+        getTaskExecutions: () => vscode.tasks.taskExecutions,
+        refreshVivadoProjects: () => VivadoProjectManager.instance.refresh(),
+        ...dependencies,
+    };
+}
+
+export { commandId as runVivadoSynthesisCommandId };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,10 +9,11 @@ import stopCosim from './commands/project/run/projects-stop-cosim';
 import stopCsim from './commands/project/run/projects-stop-csim';
 import stopCsynth from './commands/project/run/projects-stop-csynth';
 import openVivadoProject, { openVivadoProjectCommandId } from './commands/vivado/open-project';
+import runVivadoSynthesis, { runVivadoSynthesisCommandId } from './commands/vivado/run-synthesis';
 import { OutputConsole } from './output-console';
 import ProjectManager from './project-manager';
 import VivadoProjectManager from './vivado-project-manager';
-import ProjectsViewTreeProvider, { ProjectFileItem, ProjectSourceItem, ProjectTestBenchItem, VivadoProjectTreeItem } from './views/projects-tree';
+import ProjectsViewTreeProvider, { ProjectFileItem, ProjectSourceItem, ProjectTestBenchItem, VivadoProjectTreeItem, VivadoRunTreeItem } from './views/projects-tree';
 
 // TODO Make Vitis Unified IDE optional
 // TODO Proper feedback to let ppl know they don't have Vitis Unified IDE
@@ -43,6 +44,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('vitis-hls-ide.projects.testbench.addFiles', (e: ProjectTestBenchItem) => addFiles(e.project, true)),
 		vscode.commands.registerCommand('vitis-hls-ide.projects.testbench.removeFile', (e: ProjectFileItem) => removeFile(e.project, e.resourceUri!, true)),
 		vscode.commands.registerCommand(openVivadoProjectCommandId, (e?: VivadoProjectTreeItem) => openVivadoProject(e?.project)),
+		vscode.commands.registerCommand(runVivadoSynthesisCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => runVivadoSynthesis(e)),
 		projectsViewProvider,
 		OutputConsole.instance,
 		ProjectManager.instance,

--- a/src/test/commands/vivado-run-synthesis.test.ts
+++ b/src/test/commands/vivado-run-synthesis.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for running Vivado synthesis through generated TCL.
+ * Covers the first implementation slice for #11.
+ */
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { vivadoTaskSource } from '../../constants';
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoRun, VivadoRunStatus, VivadoRunType } from '../../models/vivado-run';
+import {
+    buildVivadoSynthesisTaskName,
+    buildVivadoSynthesisTcl,
+    resolveSynthesisTarget,
+    runVivadoSynthesisCommandId,
+} from '../../commands/vivado/run-synthesis';
+import runVivadoSynthesis from '../../commands/vivado/run-synthesis';
+import { quoteTclString } from '../../utils/vivado-tcl';
+
+function makeProject(runs: VivadoRun[] = [makeSynthesisRun('synth_1')]): VivadoProject {
+    return new VivadoProject({
+        name: 'demo',
+        uri: vscode.Uri.file('/workspace/demo'),
+        xprFile: vscode.Uri.file('/workspace/demo/demo.xpr'),
+        runs,
+    });
+}
+
+function makeSynthesisRun(name: string): VivadoRun {
+    return new VivadoRun({
+        name,
+        type: VivadoRunType.Synthesis,
+        status: VivadoRunStatus.NotStarted,
+    });
+}
+
+function makeImplementationRun(name: string): VivadoRun {
+    return new VivadoRun({
+        name,
+        type: VivadoRunType.Implementation,
+        status: VivadoRunStatus.NotStarted,
+        parentRunName: 'synth_1',
+    });
+}
+
+function makeVivadoTaskExecution(): vscode.TaskExecution {
+    const task = new vscode.Task(
+        { type: 'shell' },
+        vscode.TaskScope.Workspace,
+        'busy',
+        vivadoTaskSource,
+        new vscode.ShellExecution('vivado -mode batch'),
+    );
+
+    return { task } as vscode.TaskExecution;
+}
+
+suite('Vivado synthesis TCL generation', () => {
+    test('builds project-mode TCL for the selected synthesis run', () => {
+        const project = makeProject();
+        const run = project.runs[0];
+
+        assert.strictEqual(
+            buildVivadoSynthesisTcl(project, run),
+            [
+                `open_project ${quoteTclString(project.xprFile.fsPath)}`,
+                `launch_runs ${quoteTclString(run.name)}`,
+                `wait_on_run ${quoteTclString(run.name)}`,
+                `if {[get_property PROGRESS [get_runs ${quoteTclString(run.name)}]] != "100%"} {`,
+                `    error ${quoteTclString(`Synthesis run ${run.name} did not complete`)}`,
+                '}',
+                'close_project',
+            ].join('\n'),
+        );
+    });
+
+    test('builds stable task names from the project and run', () => {
+        const project = makeProject();
+
+        assert.strictEqual(
+            buildVivadoSynthesisTaskName(project, project.runs[0]),
+            'Vivado: Synthesis demo/synth_1',
+        );
+    });
+});
+
+suite('Vivado synthesis target resolution', () => {
+    test('prefers synth_1 for project-level commands', () => {
+        const synth2 = makeSynthesisRun('synth_2');
+        const synth1 = makeSynthesisRun('synth_1');
+        const project = makeProject([synth2, synth1]);
+
+        assert.strictEqual(resolveSynthesisTarget(project).run, synth1);
+    });
+
+    test('falls back to the first sorted synthesis run', () => {
+        const synthB = makeSynthesisRun('synth_b');
+        const synthA = makeSynthesisRun('synth_a');
+        const project = makeProject([synthB, synthA]);
+
+        assert.strictEqual(resolveSynthesisTarget({ project }).run, synthA);
+    });
+
+    test('accepts an explicit synthesis run target', () => {
+        const run = makeSynthesisRun('custom_synth');
+        const project = makeProject([run]);
+
+        assert.deepStrictEqual(resolveSynthesisTarget({ project, run }), { project, run });
+    });
+
+    test('rejects incompatible run targets', () => {
+        const project = makeProject([makeImplementationRun('impl_1')]);
+
+        assert.throws(
+            () => resolveSynthesisTarget({ project, run: project.runs[0] }),
+            /Select a synthesis run/,
+        );
+    });
+
+    test('rejects projects without synthesis runs', () => {
+        const project = makeProject([makeImplementationRun('impl_1')]);
+
+        assert.throws(
+            () => resolveSynthesisTarget(project),
+            /has no synthesis runs/,
+        );
+    });
+});
+
+suite('runVivadoSynthesis', () => {
+    test('runs generated TCL through vivadoRun and refreshes after success', async () => {
+        const project = makeProject();
+        const run = project.runs[0];
+        let capturedTcl = '';
+        let capturedTaskName = '';
+        let capturedStartPath: vscode.Uri | undefined;
+        let infoMessage = '';
+        let refreshed = false;
+
+        const result = await runVivadoSynthesis(project, {
+            dependencies: {
+                vivadoRun: async (startPath, tcl, taskName) => {
+                    capturedStartPath = startPath;
+                    capturedTcl = tcl;
+                    capturedTaskName = taskName;
+                    return 0;
+                },
+                showInformationMessage: async message => {
+                    infoMessage = message;
+                    return undefined;
+                },
+                showErrorMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, true);
+        assert.strictEqual(capturedStartPath?.fsPath, project.uri.fsPath);
+        assert.strictEqual(capturedTaskName, buildVivadoSynthesisTaskName(project, run));
+        assert.strictEqual(capturedTcl, buildVivadoSynthesisTcl(project, run));
+        assert.ok(infoMessage.includes('Vivado synthesis completed'));
+        assert.strictEqual(refreshed, true);
+    });
+
+    test('reports missing synthesis runs without generating TCL', async () => {
+        const project = makeProject([makeImplementationRun('impl_1')]);
+        let errorMessage = '';
+        let vivadoRunCalled = false;
+
+        const result = await runVivadoSynthesis(project, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(vivadoRunCalled, false);
+        assert.ok(errorMessage.includes('has no synthesis runs'));
+    });
+
+    test('rejects concurrent Vivado tasks before generating TCL', async () => {
+        const project = makeProject();
+        let errorMessage = '';
+        let vivadoRunCalled = false;
+
+        const result = await runVivadoSynthesis(project, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                getTaskExecutions: () => [makeVivadoTaskExecution()],
+                refreshVivadoProjects: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(vivadoRunCalled, false);
+        assert.ok(errorMessage.includes('already running'));
+    });
+
+    test('reports nonzero Vivado exits without refreshing', async () => {
+        const project = makeProject();
+        let errorMessage = '';
+        let refreshed = false;
+
+        const result = await runVivadoSynthesis(project, {
+            dependencies: {
+                vivadoRun: async () => 1,
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.ok(errorMessage.includes('Vivado synthesis failed'));
+        assert.strictEqual(refreshed, false);
+    });
+});
+
+suite('Vivado synthesis package contribution', () => {
+    test('contributes Run Synthesis to project and synthesis run tree items', () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const pkg = require('../../../package.json');
+        const command = pkg.contributes.commands.find((entry: { command: string }) => entry.command === runVivadoSynthesisCommandId);
+        const paletteEntry = pkg.contributes.menus.commandPalette.find((entry: { command: string }) => entry.command === runVivadoSynthesisCommandId);
+        const contextEntries = pkg.contributes.menus['view/item/context'].filter((entry: { command: string }) => entry.command === runVivadoSynthesisCommandId);
+
+        assert.strictEqual(command.title, 'Run Synthesis');
+        assert.strictEqual(paletteEntry.when, 'false');
+        assert.deepStrictEqual(
+            contextEntries.map((entry: { when: string }) => entry.when).sort(),
+            [
+                'view == projectsView && viewItem == vivadoProjectItem',
+                'view == projectsView && viewItem == vivadoSynthesisRunItem',
+            ],
+        );
+    });
+});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -6,6 +6,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as ext from '../extension';
 import { openVivadoProjectCommandId } from '../commands/vivado/open-project';
+import { runVivadoSynthesisCommandId } from '../commands/vivado/run-synthesis';
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -107,7 +108,7 @@ suite('Extension activation', () => {
         assert.doesNotThrow(() => ext.deactivate());
     });
 
-    test('registers the Vivado open project command', async () => {
+    test('registers the Vivado commands', async () => {
         const fakeContext = makeFakeContext();
         const registeredCommands: string[] = [];
         const origRegisterCommand = vscode.commands.registerCommand.bind(vscode.commands);
@@ -130,6 +131,7 @@ suite('Extension activation', () => {
         }
 
         assert.ok(registeredCommands.includes(openVivadoProjectCommandId));
+        assert.ok(registeredCommands.includes(runVivadoSynthesisCommandId));
     });
 });
 

--- a/src/test/utils/vivado-tcl.test.ts
+++ b/src/test/utils/vivado-tcl.test.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import {
     buildVivadoTclFileContent,
     buildVivadoTclFileName,
+    quoteTclString,
     resolveVivadoTclDirectory,
     writeVisibleVivadoTclScript,
 } from '../../utils/vivado-tcl';
@@ -82,6 +83,16 @@ suite('Vivado TCL script visibility', () => {
         assert.ok(content.includes('# Working directory: /workspace/project'));
         assert.ok(content.includes('# Rerun command:'));
         assert.ok(content.endsWith('open_project project.xpr\nexit\n'));
+    });
+
+    test('quotes TCL strings used by generated Vivado commands', () => {
+        const quoted = quoteTclString('C:\\work\\$top["a"]\r\n');
+
+        assert.strictEqual(quoted[0], '"');
+        assert.strictEqual(quoted[quoted.length - 1], '"');
+        assert.ok(quoted.includes('C:\\\\work\\\\\\$top'));
+        assert.ok(quoted.includes('\\[\\"a\\"\\]'));
+        assert.ok(quoted.endsWith('\\r\\n"'));
     });
 
     test('writes the visible TCL script to disk', () => {

--- a/src/test/views/projects-tree.test.ts
+++ b/src/test/views/projects-tree.test.ts
@@ -363,6 +363,9 @@ suite('ProjectsViewTreeProvider', () => {
         const reports = await (children[4] as TestTreeNode<VivadoReportTreeItem[]>).getChildren();
 
         assert.deepStrictEqual(runs.map(run => run.label), ['synth_1', 'impl_1']);
+        assert.strictEqual(runs[0].project, vivadoProjectsProvider.projects[0]);
+        assert.strictEqual(runs[0].contextValue, 'vivadoSynthesisRunItem');
+        assert.strictEqual(runs[1].contextValue, 'vivadoImplementationRunItem');
         assert.strictEqual(runs[0].description, 'synthesis: complete');
         assert.strictEqual(runs[1].description, 'implementation: running');
         assert.strictEqual(reports[0].label, 'timing_summary.rpt');

--- a/src/utils/vivado-tcl.ts
+++ b/src/utils/vivado-tcl.ts
@@ -73,6 +73,17 @@ export function buildVivadoTclFileContent(tcl: string, metadata: VivadoTclFileCo
     ].join('\n');
 }
 
+export function quoteTclString(value: string): string {
+    return `"${value
+        .replace(/\\/g, '\\\\')
+        .replace(/\$/g, '\\$')
+        .replace(/"/g, '\\"')
+        .replace(/\[/g, '\\[')
+        .replace(/\]/g, '\\]')
+        .replace(/\r/g, '\\r')
+        .replace(/\n/g, '\\n')}"`;
+}
+
 function formatTimestamp(now: Date): string {
     return [
         now.getUTCFullYear().toString().padStart(4, '0'),

--- a/src/views/projects-tree.ts
+++ b/src/views/projects-tree.ts
@@ -113,7 +113,7 @@ export class VivadoProjectTreeItem extends TreeItem {
             'vivadoConstraintFileItem',
             () => this.project.constraints,
         );
-        this._runsItem = new VivadoRunsItem(() => this.project.runs);
+        this._runsItem = new VivadoRunsItem(() => this.project, () => this.project.runs);
         this._reportsItem = new VivadoReportsItem(() => this.project.reports);
 
         this.updateProject(project);
@@ -183,12 +183,14 @@ export class VivadoProjectFileItem extends TreeItem {
 }
 
 class VivadoRunsItem extends TreeItem {
+    private readonly _getProject: () => VivadoProject;
     private readonly _getRuns: () => VivadoRun[];
 
-    constructor(getRuns: () => VivadoRun[]) {
+    constructor(getProject: () => VivadoProject, getRuns: () => VivadoRun[]) {
         super('Runs', vscode.TreeItemCollapsibleState.Collapsed);
         this.contextValue = 'vivadoRunsItem';
         this.iconPath = new vscode.ThemeIcon('run-all');
+        this._getProject = getProject;
         this._getRuns = getRuns;
     }
 
@@ -196,17 +198,19 @@ class VivadoRunsItem extends TreeItem {
         return Promise.resolve(this._getRuns()
             .slice()
             .sort(compareVivadoRuns)
-            .map(run => new VivadoRunTreeItem(run)));
+            .map(run => new VivadoRunTreeItem(this._getProject(), run)));
     }
 }
 
 export class VivadoRunTreeItem extends TreeItem {
+    public readonly project: VivadoProject;
     public readonly run: VivadoRun;
 
-    constructor(run: VivadoRun) {
+    constructor(project: VivadoProject, run: VivadoRun) {
         super(run.name);
+        this.project = project;
         this.run = run;
-        this.contextValue = 'vivadoRunItem';
+        this.contextValue = contextValueForRunType(run.type);
         this.description = `${formatRunType(run.type)}: ${formatRunStatus(run.status)}`;
         this.tooltip = [
             `Run: ${run.name}`,
@@ -216,6 +220,17 @@ export class VivadoRunTreeItem extends TreeItem {
             run.parentRunName ? `Parent: ${run.parentRunName}` : undefined,
         ].filter((line): line is string => Boolean(line)).join('\n');
         this.iconPath = iconForRunStatus(run.status);
+    }
+}
+
+function contextValueForRunType(type: VivadoRunType): string {
+    switch (type) {
+        case VivadoRunType.Synthesis:
+            return 'vivadoSynthesisRunItem';
+        case VivadoRunType.Implementation:
+            return 'vivadoImplementationRunItem';
+        default:
+            return 'vivadoRunItem';
     }
 }
 


### PR DESCRIPTION
## Summary
- Add the first #11 implementation slice: Run Synthesis for Vivado projects and synthesis run nodes.
- Move TCL string quoting into the shared Vivado TCL utility and reuse it from Open in Vivado.
- Carry Vivado project ownership into run tree items and add synthesis-specific tree context menus.
- Document Run Synthesis as a current Vivado feature.

## Validation
- npm run compile
- npm run lint
- npm test
- python -m mkdocs build --strict

Refs #11