### PR TITLE
feat: add Vivado implementation command

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -103,6 +103,14 @@ node to launch the selected project-mode synthesis run as a VS Code task. The
 command generates visible TCL that opens the `.xpr`, calls `launch_runs`, waits
 for the run, and checks that Vivado reports `PROGRESS` as `100%`.
 
+### Run Implementation
+
+Use the `Run Implementation` context action on a Vivado project node or
+implementation run node to launch the selected project-mode implementation run
+as a VS Code task. The command generates visible TCL that opens the `.xpr`,
+calls `launch_runs`, waits for the run, and checks that Vivado reports
+`PROGRESS` as `100%`.
+
 ## Planned Vivado Features
 
 The extension should grow from HLS project management into Vivado project support. The desired Vivado features are listed here as the product target.
@@ -129,7 +137,6 @@ Expose common Vivado runs as VS Code commands and tasks:
 
 - Elaborate design.
 - Run behavioral simulation.
-- Run implementation.
 - Generate bitstream.
 - Open timing, utilization, DRC, and power reports.
 

--- a/package.json
+++ b/package.json
@@ -134,6 +134,11 @@
         "command": "vscode-vivado.projects.runSynthesis",
         "title": "Run Synthesis",
         "icon": "$(debug-start)"
+      },
+      {
+        "command": "vscode-vivado.projects.runImplementation",
+        "title": "Run Implementation",
+        "icon": "$(debug-start)"
       }
     ],
     "viewsContainers": {
@@ -182,6 +187,10 @@
         {
           "command": "vscode-vivado.projects.runSynthesis",
           "when": "false"
+        },
+        {
+          "command": "vscode-vivado.projects.runImplementation",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -225,6 +234,16 @@
         {
           "command": "vscode-vivado.projects.runSynthesis",
           "when": "view == projectsView && viewItem == vivadoSynthesisRunItem",
+          "group": "inline"
+        },
+        {
+          "command": "vscode-vivado.projects.runImplementation",
+          "when": "view == projectsView && viewItem == vivadoProjectItem",
+          "group": "inline@2"
+        },
+        {
+          "command": "vscode-vivado.projects.runImplementation",
+          "when": "view == projectsView && viewItem == vivadoImplementationRunItem",
           "group": "inline"
         }
       ]

--- a/src/commands/vivado/run-command.ts
+++ b/src/commands/vivado/run-command.ts
@@ -1,0 +1,171 @@
+import * as vscode from 'vscode';
+import { vivadoTaskSource } from '../../constants';
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoRun, VivadoRunType } from '../../models/vivado-run';
+import VivadoProjectManager from '../../vivado-project-manager';
+import { vivadoRun, VivadoRunOptions } from '../../utils/vivado-run';
+
+export interface VivadoRunCommandTarget {
+    project?: VivadoProject;
+    run?: VivadoRun;
+}
+
+export interface RunVivadoCommandDependencies {
+    vivadoRun: (startPath: vscode.Uri, tcl: string, taskName: string, options?: VivadoRunOptions) => Promise<number | undefined>;
+    showErrorMessage: (message: string) => Thenable<string | undefined>;
+    showInformationMessage: (message: string) => Thenable<string | undefined>;
+    getTaskExecutions: () => readonly vscode.TaskExecution[];
+    refreshVivadoProjects: () => void | Promise<void>;
+}
+
+export interface RunVivadoCommandOptions {
+    dependencies?: Partial<RunVivadoCommandDependencies>;
+}
+
+export interface ResolvedVivadoRunCommand {
+    project: VivadoProject;
+    run: VivadoRun;
+}
+
+export interface VivadoRunCommandDefinition {
+    actionName: string;
+    taskActionName: string;
+    runType: VivadoRunType;
+    defaultRunName: string;
+    buildTcl: (project: VivadoProject, run: VivadoRun) => string;
+}
+
+export async function runVivadoProjectCommand(
+    target: VivadoProject | VivadoRunCommandTarget | undefined,
+    definition: VivadoRunCommandDefinition,
+    options: RunVivadoCommandOptions = {},
+): Promise<boolean> {
+    const dependencies = resolveDependencies(options.dependencies);
+
+    try {
+        const { project, run } = resolveVivadoRunTarget(target, definition);
+        ensureNoActiveVivadoTask(dependencies.getTaskExecutions(), definition.actionName);
+
+        const taskName = buildVivadoRunTaskName(definition.taskActionName, project, run);
+        const exitCode = await dependencies.vivadoRun(
+            project.uri,
+            definition.buildTcl(project, run),
+            taskName,
+            {
+                presentationOptions: {
+                    reveal: vscode.TaskRevealKind.Always,
+                    panel: vscode.TaskPanelKind.Shared,
+                    clear: false,
+                },
+            },
+        );
+
+        if (exitCode === 0) {
+            await dependencies.showInformationMessage(
+                `Vivado ${definition.actionName} completed for ${project.name}/${run.name}.`,
+            );
+            await dependencies.refreshVivadoProjects();
+            return true;
+        }
+
+        if (exitCode === undefined) {
+            return false;
+        }
+
+        await dependencies.showErrorMessage(
+            `Vivado ${definition.actionName} failed for ${project.name}/${run.name}. ` +
+            'Review the Vivado task output and generated TCL script.',
+        );
+        return false;
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        await dependencies.showErrorMessage(message);
+        return false;
+    }
+}
+
+export function resolveVivadoRunTarget(
+    target: VivadoProject | VivadoRunCommandTarget | undefined,
+    definition: Pick<VivadoRunCommandDefinition, 'actionName' | 'runType' | 'defaultRunName'>,
+): ResolvedVivadoRunCommand {
+    if (!target) {
+        throw new Error(
+            `Select a Vivado project or ${articleFor(definition.actionName)} ${definition.actionName} run in the Projects view ` +
+            `before running ${definition.actionName}.`,
+        );
+    }
+
+    if (target instanceof VivadoProject) {
+        return {
+            project: target,
+            run: chooseDefaultRun(target, definition),
+        };
+    }
+
+    if (!(target.project instanceof VivadoProject)) {
+        throw new Error(
+            `Select a Vivado project or ${articleFor(definition.actionName)} ${definition.actionName} run in the Projects view ` +
+            `before running ${definition.actionName}.`,
+        );
+    }
+
+    if (!target.run) {
+        return {
+            project: target.project,
+            run: chooseDefaultRun(target.project, definition),
+        };
+    }
+
+    if (!(target.run instanceof VivadoRun) || target.run.type !== definition.runType) {
+        throw new Error(
+            `Select ${articleFor(definition.actionName)} ${definition.actionName} run or Vivado project ` +
+            `before running ${definition.actionName}.`,
+        );
+    }
+
+    return {
+        project: target.project,
+        run: target.run,
+    };
+}
+
+export function buildVivadoRunTaskName(taskActionName: string, project: VivadoProject, run: VivadoRun): string {
+    return `Vivado: ${taskActionName} ${project.name}/${run.name}`;
+}
+
+function chooseDefaultRun(
+    project: VivadoProject,
+    definition: Pick<VivadoRunCommandDefinition, 'actionName' | 'runType' | 'defaultRunName'>,
+): VivadoRun {
+    const runs = project.runsByType(definition.runType)
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name));
+    const run = runs.find(candidate => candidate.name === definition.defaultRunName) ?? runs[0];
+
+    if (!run) {
+        throw new Error(`Vivado project ${project.name} has no ${definition.actionName} runs.`);
+    }
+
+    return run;
+}
+
+function ensureNoActiveVivadoTask(taskExecutions: readonly vscode.TaskExecution[], actionName: string): void {
+    if (taskExecutions.some(execution => execution.task.source === vivadoTaskSource)) {
+        throw new Error(`A Vivado task is already running. Wait for it to finish before starting ${actionName}.`);
+    }
+}
+
+function articleFor(value: string): 'a' | 'an' {
+    return /^[aeiou]/i.test(value) ? 'an' : 'a';
+}
+
+function resolveDependencies(dependencies: Partial<RunVivadoCommandDependencies> = {}): RunVivadoCommandDependencies {
+    return {
+        vivadoRun,
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        showInformationMessage: message => vscode.window.showInformationMessage(message),
+        getTaskExecutions: () => vscode.tasks.taskExecutions,
+        refreshVivadoProjects: () => VivadoProjectManager.instance.refresh(),
+        ...dependencies,
+    };
+}

--- a/src/commands/vivado/run-implementation.ts
+++ b/src/commands/vivado/run-implementation.ts
@@ -1,0 +1,58 @@
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoRun, VivadoRunType } from '../../models/vivado-run';
+import { quoteTclString } from '../../utils/vivado-tcl';
+import {
+    buildVivadoRunTaskName,
+    ResolvedVivadoRunCommand,
+    RunVivadoCommandDependencies,
+    RunVivadoCommandOptions,
+    runVivadoProjectCommand,
+    resolveVivadoRunTarget,
+    VivadoRunCommandDefinition,
+    VivadoRunCommandTarget,
+} from './run-command';
+
+const commandId = 'vscode-vivado.projects.runImplementation';
+
+export type RunVivadoImplementationDependencies = RunVivadoCommandDependencies;
+export type RunVivadoImplementationOptions = RunVivadoCommandOptions;
+
+const implementationCommandDefinition: VivadoRunCommandDefinition = {
+    actionName: 'implementation',
+    taskActionName: 'Implementation',
+    runType: VivadoRunType.Implementation,
+    defaultRunName: 'impl_1',
+    buildTcl: buildVivadoImplementationTcl,
+};
+
+export default async function runVivadoImplementation(
+    target: VivadoProject | VivadoRunCommandTarget | undefined,
+    options: RunVivadoImplementationOptions = {},
+): Promise<boolean> {
+    return runVivadoProjectCommand(target, implementationCommandDefinition, options);
+}
+
+export function buildVivadoImplementationTcl(project: VivadoProject, run: VivadoRun): string {
+    const projectPath = quoteTclString(project.xprFile.fsPath);
+    const runName = quoteTclString(run.name);
+
+    return [
+        `open_project ${projectPath}`,
+        `launch_runs ${runName}`,
+        `wait_on_run ${runName}`,
+        `if {[get_property PROGRESS [get_runs ${runName}]] != "100%"} {`,
+        `    error ${quoteTclString(`Implementation run ${run.name} did not complete`)}`,
+        '}',
+        'close_project',
+    ].join('\n');
+}
+
+export function buildVivadoImplementationTaskName(project: VivadoProject, run: VivadoRun): string {
+    return buildVivadoRunTaskName('Implementation', project, run);
+}
+
+export function resolveImplementationTarget(target: VivadoProject | VivadoRunCommandTarget | undefined): ResolvedVivadoRunCommand {
+    return resolveVivadoRunTarget(target, implementationCommandDefinition);
+}
+
+export { commandId as runVivadoImplementationCommandId };

--- a/src/commands/vivado/run-synthesis.ts
+++ b/src/commands/vivado/run-synthesis.ts
@@ -1,78 +1,35 @@
-import * as vscode from 'vscode';
-import { vivadoTaskSource } from '../../constants';
 import { VivadoProject } from '../../models/vivado-project';
 import { VivadoRun, VivadoRunType } from '../../models/vivado-run';
-import VivadoProjectManager from '../../vivado-project-manager';
-import { vivadoRun, VivadoRunOptions } from '../../utils/vivado-run';
 import { quoteTclString } from '../../utils/vivado-tcl';
+import {
+    buildVivadoRunTaskName,
+    ResolvedVivadoRunCommand,
+    RunVivadoCommandDependencies,
+    RunVivadoCommandOptions,
+    runVivadoProjectCommand,
+    resolveVivadoRunTarget,
+    VivadoRunCommandDefinition,
+    VivadoRunCommandTarget,
+} from './run-command';
 
 const commandId = 'vscode-vivado.projects.runSynthesis';
 
-export interface VivadoRunCommandTarget {
-    project?: VivadoProject;
-    run?: VivadoRun;
-}
+export type RunVivadoSynthesisDependencies = RunVivadoCommandDependencies;
+export type RunVivadoSynthesisOptions = RunVivadoCommandOptions;
 
-export interface RunVivadoSynthesisDependencies {
-    vivadoRun: (startPath: vscode.Uri, tcl: string, taskName: string, options?: VivadoRunOptions) => Promise<number | undefined>;
-    showErrorMessage: (message: string) => Thenable<string | undefined>;
-    showInformationMessage: (message: string) => Thenable<string | undefined>;
-    getTaskExecutions: () => readonly vscode.TaskExecution[];
-    refreshVivadoProjects: () => void | Promise<void>;
-}
-
-export interface RunVivadoSynthesisOptions {
-    dependencies?: Partial<RunVivadoSynthesisDependencies>;
-}
-
-interface ResolvedVivadoRunCommand {
-    project: VivadoProject;
-    run: VivadoRun;
-}
+const synthesisCommandDefinition: VivadoRunCommandDefinition = {
+    actionName: 'synthesis',
+    taskActionName: 'Synthesis',
+    runType: VivadoRunType.Synthesis,
+    defaultRunName: 'synth_1',
+    buildTcl: buildVivadoSynthesisTcl,
+};
 
 export default async function runVivadoSynthesis(
     target: VivadoProject | VivadoRunCommandTarget | undefined,
     options: RunVivadoSynthesisOptions = {},
 ): Promise<boolean> {
-    const dependencies = resolveDependencies(options.dependencies);
-
-    try {
-        const { project, run } = resolveSynthesisTarget(target);
-        ensureNoActiveVivadoTask(dependencies.getTaskExecutions());
-
-        const taskName = buildVivadoSynthesisTaskName(project, run);
-        const exitCode = await dependencies.vivadoRun(
-            project.uri,
-            buildVivadoSynthesisTcl(project, run),
-            taskName,
-            {
-                presentationOptions: {
-                    reveal: vscode.TaskRevealKind.Always,
-                    panel: vscode.TaskPanelKind.Shared,
-                    clear: false,
-                },
-            },
-        );
-
-        if (exitCode === 0) {
-            await dependencies.showInformationMessage(`Vivado synthesis completed for ${project.name}/${run.name}.`);
-            await dependencies.refreshVivadoProjects();
-            return true;
-        }
-
-        if (exitCode === undefined) {
-            return false;
-        }
-
-        await dependencies.showErrorMessage(
-            `Vivado synthesis failed for ${project.name}/${run.name}. Review the Vivado task output and generated TCL script.`,
-        );
-        return false;
-    } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        await dependencies.showErrorMessage(message);
-        return false;
-    }
+    return runVivadoProjectCommand(target, synthesisCommandDefinition, options);
 }
 
 export function buildVivadoSynthesisTcl(project: VivadoProject, run: VivadoRun): string {
@@ -91,70 +48,11 @@ export function buildVivadoSynthesisTcl(project: VivadoProject, run: VivadoRun):
 }
 
 export function buildVivadoSynthesisTaskName(project: VivadoProject, run: VivadoRun): string {
-    return `Vivado: Synthesis ${project.name}/${run.name}`;
+    return buildVivadoRunTaskName('Synthesis', project, run);
 }
 
 export function resolveSynthesisTarget(target: VivadoProject | VivadoRunCommandTarget | undefined): ResolvedVivadoRunCommand {
-    if (!target) {
-        throw new Error('Select a Vivado project or synthesis run in the Projects view before running synthesis.');
-    }
-
-    if (target instanceof VivadoProject) {
-        return {
-            project: target,
-            run: chooseDefaultSynthesisRun(target),
-        };
-    }
-
-    if (!(target.project instanceof VivadoProject)) {
-        throw new Error('Select a Vivado project or synthesis run in the Projects view before running synthesis.');
-    }
-
-    if (!target.run) {
-        return {
-            project: target.project,
-            run: chooseDefaultSynthesisRun(target.project),
-        };
-    }
-
-    if (!(target.run instanceof VivadoRun) || target.run.type !== VivadoRunType.Synthesis) {
-        throw new Error('Select a synthesis run or Vivado project before running synthesis.');
-    }
-
-    return {
-        project: target.project,
-        run: target.run,
-    };
-}
-
-function chooseDefaultSynthesisRun(project: VivadoProject): VivadoRun {
-    const synthesisRuns = project.runsByType(VivadoRunType.Synthesis)
-        .slice()
-        .sort((a, b) => a.name.localeCompare(b.name));
-    const run = synthesisRuns.find(candidate => candidate.name === 'synth_1') ?? synthesisRuns[0];
-
-    if (!run) {
-        throw new Error(`Vivado project ${project.name} has no synthesis runs.`);
-    }
-
-    return run;
-}
-
-function ensureNoActiveVivadoTask(taskExecutions: readonly vscode.TaskExecution[]): void {
-    if (taskExecutions.some(execution => execution.task.source === vivadoTaskSource)) {
-        throw new Error('A Vivado task is already running. Wait for it to finish before starting synthesis.');
-    }
-}
-
-function resolveDependencies(dependencies: Partial<RunVivadoSynthesisDependencies> = {}): RunVivadoSynthesisDependencies {
-    return {
-        vivadoRun,
-        showErrorMessage: message => vscode.window.showErrorMessage(message),
-        showInformationMessage: message => vscode.window.showInformationMessage(message),
-        getTaskExecutions: () => vscode.tasks.taskExecutions,
-        refreshVivadoProjects: () => VivadoProjectManager.instance.refresh(),
-        ...dependencies,
-    };
+    return resolveVivadoRunTarget(target, synthesisCommandDefinition);
 }
 
 export { commandId as runVivadoSynthesisCommandId };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import stopCosim from './commands/project/run/projects-stop-cosim';
 import stopCsim from './commands/project/run/projects-stop-csim';
 import stopCsynth from './commands/project/run/projects-stop-csynth';
 import openVivadoProject, { openVivadoProjectCommandId } from './commands/vivado/open-project';
+import runVivadoImplementation, { runVivadoImplementationCommandId } from './commands/vivado/run-implementation';
 import runVivadoSynthesis, { runVivadoSynthesisCommandId } from './commands/vivado/run-synthesis';
 import { OutputConsole } from './output-console';
 import ProjectManager from './project-manager';
@@ -45,6 +46,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('vitis-hls-ide.projects.testbench.removeFile', (e: ProjectFileItem) => removeFile(e.project, e.resourceUri!, true)),
 		vscode.commands.registerCommand(openVivadoProjectCommandId, (e?: VivadoProjectTreeItem) => openVivadoProject(e?.project)),
 		vscode.commands.registerCommand(runVivadoSynthesisCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => runVivadoSynthesis(e)),
+		vscode.commands.registerCommand(runVivadoImplementationCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => runVivadoImplementation(e)),
 		projectsViewProvider,
 		OutputConsole.instance,
 		ProjectManager.instance,

--- a/src/test/commands/vivado-run-implementation.test.ts
+++ b/src/test/commands/vivado-run-implementation.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for running Vivado implementation through generated TCL.
+ * Covers the second implementation slice for #11.
+ */
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { vivadoTaskSource } from '../../constants';
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoRun, VivadoRunStatus, VivadoRunType } from '../../models/vivado-run';
+import {
+    buildVivadoImplementationTaskName,
+    buildVivadoImplementationTcl,
+    resolveImplementationTarget,
+    runVivadoImplementationCommandId,
+} from '../../commands/vivado/run-implementation';
+import runVivadoImplementation from '../../commands/vivado/run-implementation';
+import { quoteTclString } from '../../utils/vivado-tcl';
+
+function makeProject(runs: VivadoRun[] = [makeImplementationRun('impl_1')]): VivadoProject {
+    return new VivadoProject({
+        name: 'demo',
+        uri: vscode.Uri.file('/workspace/demo'),
+        xprFile: vscode.Uri.file('/workspace/demo/demo.xpr'),
+        runs,
+    });
+}
+
+function makeSynthesisRun(name: string): VivadoRun {
+    return new VivadoRun({
+        name,
+        type: VivadoRunType.Synthesis,
+        status: VivadoRunStatus.NotStarted,
+    });
+}
+
+function makeImplementationRun(name: string): VivadoRun {
+    return new VivadoRun({
+        name,
+        type: VivadoRunType.Implementation,
+        status: VivadoRunStatus.NotStarted,
+        parentRunName: 'synth_1',
+    });
+}
+
+function makeVivadoTaskExecution(): vscode.TaskExecution {
+    const task = new vscode.Task(
+        { type: 'shell' },
+        vscode.TaskScope.Workspace,
+        'busy',
+        vivadoTaskSource,
+        new vscode.ShellExecution('vivado -mode batch'),
+    );
+
+    return { task } as vscode.TaskExecution;
+}
+
+suite('Vivado implementation TCL generation', () => {
+    test('builds project-mode TCL for the selected implementation run', () => {
+        const project = makeProject();
+        const run = project.runs[0];
+
+        assert.strictEqual(
+            buildVivadoImplementationTcl(project, run),
+            [
+                `open_project ${quoteTclString(project.xprFile.fsPath)}`,
+                `launch_runs ${quoteTclString(run.name)}`,
+                `wait_on_run ${quoteTclString(run.name)}`,
+                `if {[get_property PROGRESS [get_runs ${quoteTclString(run.name)}]] != "100%"} {`,
+                `    error ${quoteTclString(`Implementation run ${run.name} did not complete`)}`,
+                '}',
+                'close_project',
+            ].join('\n'),
+        );
+    });
+
+    test('builds stable task names from the project and run', () => {
+        const project = makeProject();
+
+        assert.strictEqual(
+            buildVivadoImplementationTaskName(project, project.runs[0]),
+            'Vivado: Implementation demo/impl_1',
+        );
+    });
+});
+
+suite('Vivado implementation target resolution', () => {
+    test('prefers impl_1 for project-level commands', () => {
+        const impl2 = makeImplementationRun('impl_2');
+        const impl1 = makeImplementationRun('impl_1');
+        const project = makeProject([impl2, impl1]);
+
+        assert.strictEqual(resolveImplementationTarget(project).run, impl1);
+    });
+
+    test('falls back to the first sorted implementation run', () => {
+        const implB = makeImplementationRun('impl_b');
+        const implA = makeImplementationRun('impl_a');
+        const project = makeProject([implB, implA]);
+
+        assert.strictEqual(resolveImplementationTarget({ project }).run, implA);
+    });
+
+    test('accepts an explicit implementation run target', () => {
+        const run = makeImplementationRun('custom_impl');
+        const project = makeProject([run]);
+
+        assert.deepStrictEqual(resolveImplementationTarget({ project, run }), { project, run });
+    });
+
+    test('rejects incompatible run targets', () => {
+        const project = makeProject([makeSynthesisRun('synth_1')]);
+
+        assert.throws(
+            () => resolveImplementationTarget({ project, run: project.runs[0] }),
+            /Select an implementation run/,
+        );
+    });
+
+    test('rejects projects without implementation runs', () => {
+        const project = makeProject([makeSynthesisRun('synth_1')]);
+
+        assert.throws(
+            () => resolveImplementationTarget(project),
+            /has no implementation runs/,
+        );
+    });
+});
+
+suite('runVivadoImplementation', () => {
+    test('runs generated TCL through vivadoRun and refreshes after success', async () => {
+        const project = makeProject();
+        const run = project.runs[0];
+        let capturedTcl = '';
+        let capturedTaskName = '';
+        let capturedStartPath: vscode.Uri | undefined;
+        let infoMessage = '';
+        let refreshed = false;
+
+        const result = await runVivadoImplementation(project, {
+            dependencies: {
+                vivadoRun: async (startPath, tcl, taskName) => {
+                    capturedStartPath = startPath;
+                    capturedTcl = tcl;
+                    capturedTaskName = taskName;
+                    return 0;
+                },
+                showInformationMessage: async message => {
+                    infoMessage = message;
+                    return undefined;
+                },
+                showErrorMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, true);
+        assert.strictEqual(capturedStartPath?.fsPath, project.uri.fsPath);
+        assert.strictEqual(capturedTaskName, buildVivadoImplementationTaskName(project, run));
+        assert.strictEqual(capturedTcl, buildVivadoImplementationTcl(project, run));
+        assert.ok(infoMessage.includes('Vivado implementation completed'));
+        assert.strictEqual(refreshed, true);
+    });
+
+    test('reports missing implementation runs without generating TCL', async () => {
+        const project = makeProject([makeSynthesisRun('synth_1')]);
+        let errorMessage = '';
+        let vivadoRunCalled = false;
+
+        const result = await runVivadoImplementation(project, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(vivadoRunCalled, false);
+        assert.ok(errorMessage.includes('has no implementation runs'));
+    });
+
+    test('rejects concurrent Vivado tasks before generating TCL', async () => {
+        const project = makeProject();
+        let errorMessage = '';
+        let vivadoRunCalled = false;
+
+        const result = await runVivadoImplementation(project, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                getTaskExecutions: () => [makeVivadoTaskExecution()],
+                refreshVivadoProjects: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(vivadoRunCalled, false);
+        assert.ok(errorMessage.includes('already running'));
+    });
+
+    test('reports nonzero Vivado exits without refreshing', async () => {
+        const project = makeProject();
+        let errorMessage = '';
+        let refreshed = false;
+
+        const result = await runVivadoImplementation(project, {
+            dependencies: {
+                vivadoRun: async () => 1,
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.ok(errorMessage.includes('Vivado implementation failed'));
+        assert.strictEqual(refreshed, false);
+    });
+});
+
+suite('Vivado implementation package contribution', () => {
+    test('contributes Run Implementation to project and implementation run tree items', () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const pkg = require('../../../package.json');
+        const command = pkg.contributes.commands.find((entry: { command: string }) => entry.command === runVivadoImplementationCommandId);
+        const paletteEntry = pkg.contributes.menus.commandPalette.find((entry: { command: string }) => entry.command === runVivadoImplementationCommandId);
+        const contextEntries = pkg.contributes.menus['view/item/context'].filter((entry: { command: string }) => entry.command === runVivadoImplementationCommandId);
+
+        assert.strictEqual(command.title, 'Run Implementation');
+        assert.strictEqual(paletteEntry.when, 'false');
+        assert.deepStrictEqual(
+            contextEntries.map((entry: { when: string }) => entry.when).sort(),
+            [
+                'view == projectsView && viewItem == vivadoImplementationRunItem',
+                'view == projectsView && viewItem == vivadoProjectItem',
+            ],
+        );
+    });
+});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -6,6 +6,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as ext from '../extension';
 import { openVivadoProjectCommandId } from '../commands/vivado/open-project';
+import { runVivadoImplementationCommandId } from '../commands/vivado/run-implementation';
 import { runVivadoSynthesisCommandId } from '../commands/vivado/run-synthesis';
 
 // ── helpers ────────────────────────────────────────────────────────────────
@@ -132,6 +133,7 @@ suite('Extension activation', () => {
 
         assert.ok(registeredCommands.includes(openVivadoProjectCommandId));
         assert.ok(registeredCommands.includes(runVivadoSynthesisCommandId));
+        assert.ok(registeredCommands.includes(runVivadoImplementationCommandId));
     });
 });
 


### PR DESCRIPTION
## Summary
- Add the second #11 implementation slice: Run Implementation for Vivado projects and implementation run nodes.
- Extract shared Vivado run-command scaffolding used by synthesis and implementation commands.
- Add package contributions, activation registration, docs, and focused command tests.

## Validation
- npm run compile
- npm run lint
- npm test
- python -m mkdocs build --strict

Refs #11