### PR TITLE
feat: add Vivado bitstream command

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -111,6 +111,14 @@ as a VS Code task. The command generates visible TCL that opens the `.xpr`,
 calls `launch_runs`, waits for the run, and checks that Vivado reports
 `PROGRESS` as `100%`.
 
+### Generate Bitstream
+
+Use the `Generate Bitstream` context action on a Vivado project node or
+implementation run node to launch bitstream generation through the selected
+project-mode implementation run. The command generates visible TCL that opens
+the `.xpr`, calls `launch_runs -to_step write_bitstream`, waits for the run,
+and checks that Vivado reports `PROGRESS` as `100%`.
+
 ## Planned Vivado Features
 
 The extension should grow from HLS project management into Vivado project support. The desired Vivado features are listed here as the product target.
@@ -137,7 +145,6 @@ Expose common Vivado runs as VS Code commands and tasks:
 
 - Elaborate design.
 - Run behavioral simulation.
-- Generate bitstream.
 - Open timing, utilization, DRC, and power reports.
 
 The extension should use Vivado TCL under the hood so every action can be reproduced outside VS Code.

--- a/package.json
+++ b/package.json
@@ -139,6 +139,11 @@
         "command": "vscode-vivado.projects.runImplementation",
         "title": "Run Implementation",
         "icon": "$(debug-start)"
+      },
+      {
+        "command": "vscode-vivado.projects.generateBitstream",
+        "title": "Generate Bitstream",
+        "icon": "$(circuit-board)"
       }
     ],
     "viewsContainers": {
@@ -190,6 +195,10 @@
         },
         {
           "command": "vscode-vivado.projects.runImplementation",
+          "when": "false"
+        },
+        {
+          "command": "vscode-vivado.projects.generateBitstream",
           "when": "false"
         }
       ],
@@ -245,6 +254,16 @@
           "command": "vscode-vivado.projects.runImplementation",
           "when": "view == projectsView && viewItem == vivadoImplementationRunItem",
           "group": "inline"
+        },
+        {
+          "command": "vscode-vivado.projects.generateBitstream",
+          "when": "view == projectsView && viewItem == vivadoProjectItem",
+          "group": "inline@3"
+        },
+        {
+          "command": "vscode-vivado.projects.generateBitstream",
+          "when": "view == projectsView && viewItem == vivadoImplementationRunItem",
+          "group": "inline@1"
         }
       ]
     },

--- a/src/commands/vivado/generate-bitstream.ts
+++ b/src/commands/vivado/generate-bitstream.ts
@@ -1,0 +1,59 @@
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoRun, VivadoRunType } from '../../models/vivado-run';
+import { quoteTclString } from '../../utils/vivado-tcl';
+import {
+    buildVivadoRunTaskName,
+    ResolvedVivadoRunCommand,
+    RunVivadoCommandDependencies,
+    RunVivadoCommandOptions,
+    runVivadoProjectCommand,
+    resolveVivadoRunTarget,
+    VivadoRunCommandDefinition,
+    VivadoRunCommandTarget,
+} from './run-command';
+
+const commandId = 'vscode-vivado.projects.generateBitstream';
+
+export type GenerateVivadoBitstreamDependencies = RunVivadoCommandDependencies;
+export type GenerateVivadoBitstreamOptions = RunVivadoCommandOptions;
+
+const bitstreamCommandDefinition: VivadoRunCommandDefinition = {
+    actionName: 'bitstream generation',
+    taskActionName: 'Bitstream',
+    runType: VivadoRunType.Implementation,
+    runDescription: 'implementation',
+    defaultRunName: 'impl_1',
+    buildTcl: buildVivadoBitstreamTcl,
+};
+
+export default async function generateVivadoBitstream(
+    target: VivadoProject | VivadoRunCommandTarget | undefined,
+    options: GenerateVivadoBitstreamOptions = {},
+): Promise<boolean> {
+    return runVivadoProjectCommand(target, bitstreamCommandDefinition, options);
+}
+
+export function buildVivadoBitstreamTcl(project: VivadoProject, run: VivadoRun): string {
+    const projectPath = quoteTclString(project.xprFile.fsPath);
+    const runName = quoteTclString(run.name);
+
+    return [
+        `open_project ${projectPath}`,
+        `launch_runs ${runName} -to_step write_bitstream`,
+        `wait_on_run ${runName}`,
+        `if {[get_property PROGRESS [get_runs ${runName}]] != "100%"} {`,
+        `    error ${quoteTclString(`Bitstream run ${run.name} did not complete`)}`,
+        '}',
+        'close_project',
+    ].join('\n');
+}
+
+export function buildVivadoBitstreamTaskName(project: VivadoProject, run: VivadoRun): string {
+    return buildVivadoRunTaskName('Bitstream', project, run);
+}
+
+export function resolveBitstreamTarget(target: VivadoProject | VivadoRunCommandTarget | undefined): ResolvedVivadoRunCommand {
+    return resolveVivadoRunTarget(target, bitstreamCommandDefinition);
+}
+
+export { commandId as generateVivadoBitstreamCommandId };

--- a/src/commands/vivado/run-command.ts
+++ b/src/commands/vivado/run-command.ts
@@ -31,6 +31,7 @@ export interface VivadoRunCommandDefinition {
     actionName: string;
     taskActionName: string;
     runType: VivadoRunType;
+    runDescription?: string;
     defaultRunName: string;
     buildTcl: (project: VivadoProject, run: VivadoRun) => string;
 }
@@ -86,11 +87,13 @@ export async function runVivadoProjectCommand(
 
 export function resolveVivadoRunTarget(
     target: VivadoProject | VivadoRunCommandTarget | undefined,
-    definition: Pick<VivadoRunCommandDefinition, 'actionName' | 'runType' | 'defaultRunName'>,
+    definition: Pick<VivadoRunCommandDefinition, 'actionName' | 'runType' | 'runDescription' | 'defaultRunName'>,
 ): ResolvedVivadoRunCommand {
+    const runDescription = getRunDescription(definition);
+
     if (!target) {
         throw new Error(
-            `Select a Vivado project or ${articleFor(definition.actionName)} ${definition.actionName} run in the Projects view ` +
+            `Select a Vivado project or ${articleFor(runDescription)} ${runDescription} run in the Projects view ` +
             `before running ${definition.actionName}.`,
         );
     }
@@ -104,7 +107,7 @@ export function resolveVivadoRunTarget(
 
     if (!(target.project instanceof VivadoProject)) {
         throw new Error(
-            `Select a Vivado project or ${articleFor(definition.actionName)} ${definition.actionName} run in the Projects view ` +
+            `Select a Vivado project or ${articleFor(runDescription)} ${runDescription} run in the Projects view ` +
             `before running ${definition.actionName}.`,
         );
     }
@@ -118,7 +121,7 @@ export function resolveVivadoRunTarget(
 
     if (!(target.run instanceof VivadoRun) || target.run.type !== definition.runType) {
         throw new Error(
-            `Select ${articleFor(definition.actionName)} ${definition.actionName} run or Vivado project ` +
+            `Select ${articleFor(runDescription)} ${runDescription} run or Vivado project ` +
             `before running ${definition.actionName}.`,
         );
     }
@@ -135,7 +138,7 @@ export function buildVivadoRunTaskName(taskActionName: string, project: VivadoPr
 
 function chooseDefaultRun(
     project: VivadoProject,
-    definition: Pick<VivadoRunCommandDefinition, 'actionName' | 'runType' | 'defaultRunName'>,
+    definition: Pick<VivadoRunCommandDefinition, 'actionName' | 'runType' | 'runDescription' | 'defaultRunName'>,
 ): VivadoRun {
     const runs = project.runsByType(definition.runType)
         .slice()
@@ -143,7 +146,7 @@ function chooseDefaultRun(
     const run = runs.find(candidate => candidate.name === definition.defaultRunName) ?? runs[0];
 
     if (!run) {
-        throw new Error(`Vivado project ${project.name} has no ${definition.actionName} runs.`);
+        throw new Error(`Vivado project ${project.name} has no ${getRunDescription(definition)} runs.`);
     }
 
     return run;
@@ -157,6 +160,10 @@ function ensureNoActiveVivadoTask(taskExecutions: readonly vscode.TaskExecution[
 
 function articleFor(value: string): 'a' | 'an' {
     return /^[aeiou]/i.test(value) ? 'an' : 'a';
+}
+
+function getRunDescription(definition: Pick<VivadoRunCommandDefinition, 'actionName' | 'runDescription'>): string {
+    return definition.runDescription ?? definition.actionName;
 }
 
 function resolveDependencies(dependencies: Partial<RunVivadoCommandDependencies> = {}): RunVivadoCommandDependencies {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import runCsynth from './commands/project/run/projects-run-csynth';
 import stopCosim from './commands/project/run/projects-stop-cosim';
 import stopCsim from './commands/project/run/projects-stop-csim';
 import stopCsynth from './commands/project/run/projects-stop-csynth';
+import generateVivadoBitstream, { generateVivadoBitstreamCommandId } from './commands/vivado/generate-bitstream';
 import openVivadoProject, { openVivadoProjectCommandId } from './commands/vivado/open-project';
 import runVivadoImplementation, { runVivadoImplementationCommandId } from './commands/vivado/run-implementation';
 import runVivadoSynthesis, { runVivadoSynthesisCommandId } from './commands/vivado/run-synthesis';
@@ -47,6 +48,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand(openVivadoProjectCommandId, (e?: VivadoProjectTreeItem) => openVivadoProject(e?.project)),
 		vscode.commands.registerCommand(runVivadoSynthesisCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => runVivadoSynthesis(e)),
 		vscode.commands.registerCommand(runVivadoImplementationCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => runVivadoImplementation(e)),
+		vscode.commands.registerCommand(generateVivadoBitstreamCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => generateVivadoBitstream(e)),
 		projectsViewProvider,
 		OutputConsole.instance,
 		ProjectManager.instance,

--- a/src/test/commands/vivado-generate-bitstream.test.ts
+++ b/src/test/commands/vivado-generate-bitstream.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for generating Vivado bitstreams through generated TCL.
+ * Covers the final implementation slice for #11.
+ */
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { vivadoTaskSource } from '../../constants';
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoRun, VivadoRunStatus, VivadoRunType } from '../../models/vivado-run';
+import {
+    buildVivadoBitstreamTaskName,
+    buildVivadoBitstreamTcl,
+    generateVivadoBitstreamCommandId,
+    resolveBitstreamTarget,
+} from '../../commands/vivado/generate-bitstream';
+import generateVivadoBitstream from '../../commands/vivado/generate-bitstream';
+import { quoteTclString } from '../../utils/vivado-tcl';
+
+function makeProject(runs: VivadoRun[] = [makeImplementationRun('impl_1')]): VivadoProject {
+    return new VivadoProject({
+        name: 'demo',
+        uri: vscode.Uri.file('/workspace/demo'),
+        xprFile: vscode.Uri.file('/workspace/demo/demo.xpr'),
+        runs,
+    });
+}
+
+function makeSynthesisRun(name: string): VivadoRun {
+    return new VivadoRun({
+        name,
+        type: VivadoRunType.Synthesis,
+        status: VivadoRunStatus.NotStarted,
+    });
+}
+
+function makeImplementationRun(name: string): VivadoRun {
+    return new VivadoRun({
+        name,
+        type: VivadoRunType.Implementation,
+        status: VivadoRunStatus.NotStarted,
+        parentRunName: 'synth_1',
+    });
+}
+
+function makeVivadoTaskExecution(): vscode.TaskExecution {
+    const task = new vscode.Task(
+        { type: 'shell' },
+        vscode.TaskScope.Workspace,
+        'busy',
+        vivadoTaskSource,
+        new vscode.ShellExecution('vivado -mode batch'),
+    );
+
+    return { task } as vscode.TaskExecution;
+}
+
+suite('Vivado bitstream TCL generation', () => {
+    test('builds project-mode TCL for the selected implementation run', () => {
+        const project = makeProject();
+        const run = project.runs[0];
+
+        assert.strictEqual(
+            buildVivadoBitstreamTcl(project, run),
+            [
+                `open_project ${quoteTclString(project.xprFile.fsPath)}`,
+                `launch_runs ${quoteTclString(run.name)} -to_step write_bitstream`,
+                `wait_on_run ${quoteTclString(run.name)}`,
+                `if {[get_property PROGRESS [get_runs ${quoteTclString(run.name)}]] != "100%"} {`,
+                `    error ${quoteTclString(`Bitstream run ${run.name} did not complete`)}`,
+                '}',
+                'close_project',
+            ].join('\n'),
+        );
+    });
+
+    test('builds stable task names from the project and run', () => {
+        const project = makeProject();
+
+        assert.strictEqual(
+            buildVivadoBitstreamTaskName(project, project.runs[0]),
+            'Vivado: Bitstream demo/impl_1',
+        );
+    });
+});
+
+suite('Vivado bitstream target resolution', () => {
+    test('prefers impl_1 for project-level commands', () => {
+        const impl2 = makeImplementationRun('impl_2');
+        const impl1 = makeImplementationRun('impl_1');
+        const project = makeProject([impl2, impl1]);
+
+        assert.strictEqual(resolveBitstreamTarget(project).run, impl1);
+    });
+
+    test('falls back to the first sorted implementation run', () => {
+        const implB = makeImplementationRun('impl_b');
+        const implA = makeImplementationRun('impl_a');
+        const project = makeProject([implB, implA]);
+
+        assert.strictEqual(resolveBitstreamTarget({ project }).run, implA);
+    });
+
+    test('accepts an explicit implementation run target', () => {
+        const run = makeImplementationRun('custom_impl');
+        const project = makeProject([run]);
+
+        assert.deepStrictEqual(resolveBitstreamTarget({ project, run }), { project, run });
+    });
+
+    test('rejects incompatible run targets', () => {
+        const project = makeProject([makeSynthesisRun('synth_1')]);
+
+        assert.throws(
+            () => resolveBitstreamTarget({ project, run: project.runs[0] }),
+            /Select an implementation run/,
+        );
+    });
+
+    test('rejects projects without implementation runs', () => {
+        const project = makeProject([makeSynthesisRun('synth_1')]);
+
+        assert.throws(
+            () => resolveBitstreamTarget(project),
+            /has no implementation runs/,
+        );
+    });
+});
+
+suite('generateVivadoBitstream', () => {
+    test('runs generated TCL through vivadoRun and refreshes after success', async () => {
+        const project = makeProject();
+        const run = project.runs[0];
+        let capturedTcl = '';
+        let capturedTaskName = '';
+        let capturedStartPath: vscode.Uri | undefined;
+        let infoMessage = '';
+        let refreshed = false;
+
+        const result = await generateVivadoBitstream(project, {
+            dependencies: {
+                vivadoRun: async (startPath, tcl, taskName) => {
+                    capturedStartPath = startPath;
+                    capturedTcl = tcl;
+                    capturedTaskName = taskName;
+                    return 0;
+                },
+                showInformationMessage: async message => {
+                    infoMessage = message;
+                    return undefined;
+                },
+                showErrorMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, true);
+        assert.strictEqual(capturedStartPath?.fsPath, project.uri.fsPath);
+        assert.strictEqual(capturedTaskName, buildVivadoBitstreamTaskName(project, run));
+        assert.strictEqual(capturedTcl, buildVivadoBitstreamTcl(project, run));
+        assert.ok(infoMessage.includes('Vivado bitstream generation completed'));
+        assert.strictEqual(refreshed, true);
+    });
+
+    test('reports missing implementation runs without generating TCL', async () => {
+        const project = makeProject([makeSynthesisRun('synth_1')]);
+        let errorMessage = '';
+        let vivadoRunCalled = false;
+
+        const result = await generateVivadoBitstream(project, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(vivadoRunCalled, false);
+        assert.ok(errorMessage.includes('has no implementation runs'));
+    });
+
+    test('rejects concurrent Vivado tasks before generating TCL', async () => {
+        const project = makeProject();
+        let errorMessage = '';
+        let vivadoRunCalled = false;
+
+        const result = await generateVivadoBitstream(project, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                getTaskExecutions: () => [makeVivadoTaskExecution()],
+                refreshVivadoProjects: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(vivadoRunCalled, false);
+        assert.ok(errorMessage.includes('already running'));
+    });
+
+    test('reports nonzero Vivado exits without refreshing', async () => {
+        const project = makeProject();
+        let errorMessage = '';
+        let refreshed = false;
+
+        const result = await generateVivadoBitstream(project, {
+            dependencies: {
+                vivadoRun: async () => 1,
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.ok(errorMessage.includes('Vivado bitstream generation failed'));
+        assert.strictEqual(refreshed, false);
+    });
+});
+
+suite('Vivado bitstream package contribution', () => {
+    test('contributes Generate Bitstream to project and implementation run tree items', () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const pkg = require('../../../package.json');
+        const command = pkg.contributes.commands.find((entry: { command: string }) => entry.command === generateVivadoBitstreamCommandId);
+        const paletteEntry = pkg.contributes.menus.commandPalette.find((entry: { command: string }) => entry.command === generateVivadoBitstreamCommandId);
+        const contextEntries = pkg.contributes.menus['view/item/context'].filter((entry: { command: string }) => entry.command === generateVivadoBitstreamCommandId);
+
+        assert.strictEqual(command.title, 'Generate Bitstream');
+        assert.strictEqual(paletteEntry.when, 'false');
+        assert.deepStrictEqual(
+            contextEntries.map((entry: { when: string }) => entry.when).sort(),
+            [
+                'view == projectsView && viewItem == vivadoImplementationRunItem',
+                'view == projectsView && viewItem == vivadoProjectItem',
+            ],
+        );
+    });
+});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -5,6 +5,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as ext from '../extension';
+import { generateVivadoBitstreamCommandId } from '../commands/vivado/generate-bitstream';
 import { openVivadoProjectCommandId } from '../commands/vivado/open-project';
 import { runVivadoImplementationCommandId } from '../commands/vivado/run-implementation';
 import { runVivadoSynthesisCommandId } from '../commands/vivado/run-synthesis';
@@ -134,6 +135,7 @@ suite('Extension activation', () => {
         assert.ok(registeredCommands.includes(openVivadoProjectCommandId));
         assert.ok(registeredCommands.includes(runVivadoSynthesisCommandId));
         assert.ok(registeredCommands.includes(runVivadoImplementationCommandId));
+        assert.ok(registeredCommands.includes(generateVivadoBitstreamCommandId));
     });
 });
 


### PR DESCRIPTION
## Summary
- Add the final #11 implementation slice: Generate Bitstream for Vivado projects and implementation run nodes.
- Use project-mode TCL with launch_runs <impl_run> -to_step write_bitstream through the shared vivadoRun task scaffold.
- Add package contributions, activation registration, docs, and focused command tests.
- Keep bitstream targeting explicit: the command selects implementation runs, not a separate bitstream run type.

## Validation
- npm run compile
- npm run lint
- npm test
- python -m mkdocs build --strict

Closes #11