### PR TITLE
feat: add Vivado reset run command

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,11 @@
         "icon": "$(open-preview)"
       },
       {
+        "command": "vscode-vivado.projects.resetRun",
+        "title": "Reset Run",
+        "icon": "$(discard)"
+      },
+      {
         "command": "vscode-vivado.projects.runSynthesis",
         "title": "Run Synthesis",
         "icon": "$(debug-start)"
@@ -196,6 +201,10 @@
         },
         {
           "command": "vscode-vivado.projects.previewGeneratedTcl",
+          "when": "false"
+        },
+        {
+          "command": "vscode-vivado.projects.resetRun",
           "when": "false"
         },
         {
@@ -265,6 +274,11 @@
           "group": "inline@1"
         },
         {
+          "command": "vscode-vivado.projects.resetRun",
+          "when": "view == projectsView && viewItem == vivadoSynthesisRunItem",
+          "group": "inline@2"
+        },
+        {
           "command": "vscode-vivado.projects.runImplementation",
           "when": "view == projectsView && viewItem == vivadoProjectItem",
           "group": "inline@2"
@@ -288,6 +302,11 @@
           "command": "vscode-vivado.projects.previewGeneratedTcl",
           "when": "view == projectsView && viewItem == vivadoImplementationRunItem",
           "group": "inline@2"
+        },
+        {
+          "command": "vscode-vivado.projects.resetRun",
+          "when": "view == projectsView && viewItem == vivadoImplementationRunItem",
+          "group": "inline@3"
         }
       ]
     },

--- a/src/commands/vivado/preview-generated-tcl.ts
+++ b/src/commands/vivado/preview-generated-tcl.ts
@@ -7,7 +7,7 @@ import {
     VivadoRunCommandTarget,
     VivadoTclActionDefinition,
 } from './run-command';
-import { vivadoBuildTclActionDefinitions } from './tcl-actions';
+import { vivadoTclActionDefinitions } from './tcl-actions';
 
 const commandId = 'vscode-vivado.projects.previewGeneratedTcl';
 
@@ -66,7 +66,7 @@ export default async function previewVivadoGeneratedTcl(
 
 export function resolveVivadoTclPreviewActions(
     target: VivadoProject | VivadoRunCommandTarget | undefined,
-    actionDefinitions: readonly VivadoTclActionDefinition[] = vivadoBuildTclActionDefinitions,
+    actionDefinitions: readonly VivadoTclActionDefinition[] = vivadoTclActionDefinitions,
 ): ResolvedVivadoTclPreviewAction[] {
     if (!target) {
         throw new Error('Select a Vivado project or run in the Projects view before previewing generated TCL.');

--- a/src/commands/vivado/reset-run.ts
+++ b/src/commands/vivado/reset-run.ts
@@ -1,0 +1,70 @@
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoRun, VivadoRunType } from '../../models/vivado-run';
+import { quoteTclString } from '../../utils/vivado-tcl';
+import {
+    buildVivadoRunTaskName,
+    ResolvedVivadoRunCommand,
+    resolveVivadoRunTarget,
+    RunVivadoCommandDependencies,
+    RunVivadoCommandOptions,
+    runVivadoProjectCommand,
+    VivadoRunCommandDefinition,
+    VivadoRunCommandTarget,
+} from './run-command';
+
+const commandId = 'vscode-vivado.projects.resetRun';
+
+export type ResetVivadoRunDependencies = RunVivadoCommandDependencies;
+export type ResetVivadoRunOptions = RunVivadoCommandOptions;
+
+export const vivadoResetRunActionDefinition: VivadoRunCommandDefinition = {
+    actionId: 'resetRun',
+    title: 'Reset Run',
+    actionName: 'reset run',
+    taskActionName: 'Reset Run',
+    runType: VivadoRunType.Synthesis,
+    runTypes: [VivadoRunType.Synthesis, VivadoRunType.Implementation],
+    runDescription: 'synthesis or implementation',
+    defaultRunName: 'synth_1',
+    supportsProjectTarget: false,
+    supportsRunTarget: true,
+    destructive: true,
+    confirmation: (project, run) => ({
+        message: `Reset Vivado run "${run.name}" in "${project.name}"?`,
+        detail: 'This resets the run state and may invalidate downstream results.',
+        confirmLabel: 'Reset Run',
+    }),
+    buildTcl: buildVivadoResetRunTcl,
+};
+
+export default async function resetVivadoRun(
+    target: VivadoProject | VivadoRunCommandTarget | undefined,
+    options: ResetVivadoRunOptions = {},
+): Promise<boolean> {
+    return runVivadoProjectCommand(target, vivadoResetRunActionDefinition, options);
+}
+
+export function buildVivadoResetRunTcl(project: VivadoProject, run: VivadoRun): string {
+    const projectPath = quoteTclString(project.xprFile.fsPath);
+    const runName = quoteTclString(run.name);
+
+    return [
+        `open_project ${projectPath}`,
+        `set selected_run [get_runs ${runName}]`,
+        'if {[llength $selected_run] != 1} {',
+        `    error ${quoteTclString(`Expected exactly one Vivado run named ${run.name}`)}`,
+        '}',
+        'reset_runs $selected_run',
+        'close_project',
+    ].join('\n');
+}
+
+export function buildVivadoResetRunTaskName(project: VivadoProject, run: VivadoRun): string {
+    return buildVivadoRunTaskName(vivadoResetRunActionDefinition.taskActionName, project, run);
+}
+
+export function resolveResetRunTarget(target: VivadoProject | VivadoRunCommandTarget | undefined): ResolvedVivadoRunCommand {
+    return resolveVivadoRunTarget(target, vivadoResetRunActionDefinition);
+}
+
+export { commandId as resetVivadoRunCommandId };

--- a/src/commands/vivado/run-command.ts
+++ b/src/commands/vivado/run-command.ts
@@ -14,6 +14,7 @@ export interface RunVivadoCommandDependencies {
     vivadoRun: (startPath: vscode.Uri, tcl: string, taskName: string, options?: VivadoRunOptions) => Promise<number | undefined>;
     showErrorMessage: (message: string) => Thenable<string | undefined>;
     showInformationMessage: (message: string) => Thenable<string | undefined>;
+    showWarningMessage: (message: string, options: vscode.MessageOptions, ...items: string[]) => Thenable<string | undefined>;
     getTaskExecutions: () => readonly vscode.TaskExecution[];
     refreshVivadoProjects: () => void | Promise<void>;
 }
@@ -33,15 +34,23 @@ export interface VivadoTclActionDefinition {
     actionName: string;
     taskActionName: string;
     runType: VivadoRunType;
+    runTypes?: readonly VivadoRunType[];
     runDescription?: string;
     defaultRunName: string;
     supportsProjectTarget: boolean;
     supportsRunTarget: boolean;
     destructive?: boolean;
+    confirmation?: (project: VivadoProject, run: VivadoRun) => VivadoRunCommandConfirmation;
     buildTcl: (project: VivadoProject, run: VivadoRun) => string;
 }
 
 export type VivadoRunCommandDefinition = VivadoTclActionDefinition;
+
+export interface VivadoRunCommandConfirmation {
+    message: string;
+    confirmLabel: string;
+    detail?: string;
+}
 
 export async function runVivadoProjectCommand(
     target: VivadoProject | VivadoRunCommandTarget | undefined,
@@ -53,6 +62,19 @@ export async function runVivadoProjectCommand(
     try {
         const { project, run } = resolveVivadoRunTarget(target, definition);
         ensureNoActiveVivadoTask(dependencies.getTaskExecutions(), definition.actionName);
+
+        const confirmation = definition.confirmation?.(project, run);
+        if (confirmation) {
+            const selection = await dependencies.showWarningMessage(
+                confirmation.message,
+                { modal: true, detail: confirmation.detail },
+                confirmation.confirmLabel,
+            );
+
+            if (selection !== confirmation.confirmLabel) {
+                return false;
+            }
+        }
 
         const taskName = buildVivadoRunTaskName(definition.taskActionName, project, run);
         const exitCode = await dependencies.vivadoRun(
@@ -94,7 +116,7 @@ export async function runVivadoProjectCommand(
 
 export function resolveVivadoRunTarget(
     target: VivadoProject | VivadoRunCommandTarget | undefined,
-    definition: Pick<VivadoRunCommandDefinition, 'actionName' | 'runType' | 'runDescription' | 'defaultRunName' | 'supportsProjectTarget' | 'supportsRunTarget'>,
+    definition: Pick<VivadoRunCommandDefinition, 'actionName' | 'runType' | 'runTypes' | 'runDescription' | 'defaultRunName' | 'supportsProjectTarget' | 'supportsRunTarget'>,
 ): ResolvedVivadoRunCommand {
     const runDescription = getRunDescription(definition);
 
@@ -140,9 +162,13 @@ export function resolveVivadoRunTarget(
         };
     }
 
-    if (!definition.supportsRunTarget || !(target.run instanceof VivadoRun) || target.run.type !== definition.runType) {
+    if (!definition.supportsRunTarget || !(target.run instanceof VivadoRun) || !supportsRunType(definition, target.run.type)) {
+        const targetDescription = definition.supportsProjectTarget
+            ? `${articleFor(runDescription)} ${runDescription} run or Vivado project`
+            : `${articleFor(runDescription)} ${runDescription} run`;
+
         throw new Error(
-            `Select ${articleFor(runDescription)} ${runDescription} run or Vivado project ` +
+            `Select ${targetDescription} ` +
             `before running ${definition.actionName}.`,
         );
     }
@@ -155,6 +181,13 @@ export function resolveVivadoRunTarget(
 
 export function buildVivadoRunTaskName(taskActionName: string, project: VivadoProject, run: VivadoRun): string {
     return `Vivado: ${taskActionName} ${project.name}/${run.name}`;
+}
+
+function supportsRunType(
+    definition: Pick<VivadoRunCommandDefinition, 'runType' | 'runTypes'>,
+    runType: VivadoRunType,
+): boolean {
+    return (definition.runTypes ?? [definition.runType]).includes(runType);
 }
 
 function chooseDefaultRun(
@@ -192,6 +225,7 @@ function resolveDependencies(dependencies: Partial<RunVivadoCommandDependencies>
         vivadoRun,
         showErrorMessage: message => vscode.window.showErrorMessage(message),
         showInformationMessage: message => vscode.window.showInformationMessage(message),
+        showWarningMessage: (message, options, ...items) => vscode.window.showWarningMessage(message, options, ...items),
         getTaskExecutions: () => vscode.tasks.taskExecutions,
         refreshVivadoProjects: () => VivadoProjectManager.instance.refresh(),
         ...dependencies,

--- a/src/commands/vivado/tcl-actions.ts
+++ b/src/commands/vivado/tcl-actions.ts
@@ -1,10 +1,20 @@
 import { vivadoBitstreamActionDefinition } from './generate-bitstream';
 import { VivadoTclActionDefinition } from './run-command';
 import { vivadoImplementationActionDefinition } from './run-implementation';
+import { vivadoResetRunActionDefinition } from './reset-run';
 import { vivadoSynthesisActionDefinition } from './run-synthesis';
 
 export const vivadoBuildTclActionDefinitions: readonly VivadoTclActionDefinition[] = [
     vivadoSynthesisActionDefinition,
     vivadoImplementationActionDefinition,
     vivadoBitstreamActionDefinition,
+];
+
+export const vivadoRunMaintenanceTclActionDefinitions: readonly VivadoTclActionDefinition[] = [
+    vivadoResetRunActionDefinition,
+];
+
+export const vivadoTclActionDefinitions: readonly VivadoTclActionDefinition[] = [
+    ...vivadoBuildTclActionDefinitions,
+    ...vivadoRunMaintenanceTclActionDefinitions,
 ];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import stopCsynth from './commands/project/run/projects-stop-csynth';
 import generateVivadoBitstream, { generateVivadoBitstreamCommandId } from './commands/vivado/generate-bitstream';
 import openVivadoProject, { openVivadoProjectCommandId } from './commands/vivado/open-project';
 import previewVivadoGeneratedTcl, { previewVivadoGeneratedTclCommandId } from './commands/vivado/preview-generated-tcl';
+import resetVivadoRun, { resetVivadoRunCommandId } from './commands/vivado/reset-run';
 import runVivadoImplementation, { runVivadoImplementationCommandId } from './commands/vivado/run-implementation';
 import runVivadoSynthesis, { runVivadoSynthesisCommandId } from './commands/vivado/run-synthesis';
 import { OutputConsole } from './output-console';
@@ -48,6 +49,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('vitis-hls-ide.projects.testbench.removeFile', (e: ProjectFileItem) => removeFile(e.project, e.resourceUri!, true)),
 		vscode.commands.registerCommand(openVivadoProjectCommandId, (e?: VivadoProjectTreeItem) => openVivadoProject(e?.project)),
 		vscode.commands.registerCommand(previewVivadoGeneratedTclCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => previewVivadoGeneratedTcl(e)),
+		vscode.commands.registerCommand(resetVivadoRunCommandId, (e?: VivadoRunTreeItem) => resetVivadoRun(e)),
 		vscode.commands.registerCommand(runVivadoSynthesisCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => runVivadoSynthesis(e)),
 		vscode.commands.registerCommand(runVivadoImplementationCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => runVivadoImplementation(e)),
 		vscode.commands.registerCommand(generateVivadoBitstreamCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => generateVivadoBitstream(e)),

--- a/src/test/commands/vivado-preview-generated-tcl.test.ts
+++ b/src/test/commands/vivado-preview-generated-tcl.test.ts
@@ -12,8 +12,9 @@ import previewVivadoGeneratedTcl, {
     VivadoTclPreviewQuickPickItem,
 } from '../../commands/vivado/preview-generated-tcl';
 import { buildVivadoImplementationTcl } from '../../commands/vivado/run-implementation';
+import { buildVivadoResetRunTcl } from '../../commands/vivado/reset-run';
 import { buildVivadoSynthesisTcl, vivadoSynthesisActionDefinition } from '../../commands/vivado/run-synthesis';
-import { vivadoBuildTclActionDefinitions } from '../../commands/vivado/tcl-actions';
+import { vivadoBuildTclActionDefinitions, vivadoTclActionDefinitions } from '../../commands/vivado/tcl-actions';
 import { VivadoProject } from '../../models/vivado-project';
 import { VivadoRun, VivadoRunStatus, VivadoRunType } from '../../models/vivado-run';
 
@@ -87,10 +88,17 @@ function makePreviewDependencies(options: {
 }
 
 suite('Vivado generated TCL preview action registry', () => {
-    test('contains the existing build actions in preview order', () => {
+    test('contains the existing build actions in build order', () => {
         assert.deepStrictEqual(
             vivadoBuildTclActionDefinitions.map(action => action.title),
             ['Run Synthesis', 'Run Implementation', 'Generate Bitstream'],
+        );
+    });
+
+    test('contains reset after the current build actions in preview order', () => {
+        assert.deepStrictEqual(
+            vivadoTclActionDefinitions.map(action => action.title),
+            ['Run Synthesis', 'Run Implementation', 'Generate Bitstream', 'Reset Run'],
         );
     });
 });
@@ -109,23 +117,23 @@ suite('Vivado generated TCL preview action resolution', () => {
         );
     });
 
-    test('offers only synthesis actions for an explicit synthesis run target', () => {
+    test('offers synthesis and reset actions for an explicit synthesis run target', () => {
         const project = makeProject();
         const run = project.runs[0];
 
         assert.deepStrictEqual(
             resolveVivadoTclPreviewActions({ project, run }).map(action => action.definition.title),
-            ['Run Synthesis'],
+            ['Run Synthesis', 'Reset Run'],
         );
     });
 
-    test('offers implementation and bitstream actions for an explicit implementation run target', () => {
+    test('offers implementation, bitstream, and reset actions for an explicit implementation run target', () => {
         const project = makeProject();
         const run = project.runs[1];
 
         assert.deepStrictEqual(
             resolveVivadoTclPreviewActions({ project, run }).map(action => action.definition.title),
-            ['Run Implementation', 'Generate Bitstream'],
+            ['Run Implementation', 'Generate Bitstream', 'Reset Run'],
         );
     });
 
@@ -207,6 +215,31 @@ suite('previewVivadoGeneratedTcl', () => {
         assert.strictEqual(shownDocument?.uri.scheme, 'untitled');
     });
 
+    test('opens reset from an explicit run quick pick', async () => {
+        const project = makeProject();
+        const run = project.runs[0];
+        let quickPickLabels: string[] = [];
+        let openedContent = '';
+
+        const result = await previewVivadoGeneratedTcl({ project, run }, {
+            dependencies: makePreviewDependencies({
+                pickTitle: 'Reset Run',
+                onQuickPick: items => {
+                    quickPickLabels = items.map(item => item.label);
+                },
+                onOpenTextDocument: options => {
+                    openedContent = options.content;
+                },
+            }),
+        });
+
+        assert.strictEqual(result, true);
+        assert.deepStrictEqual(quickPickLabels, ['Run Synthesis', 'Reset Run']);
+        assert.ok(openedContent.includes('# Action: Reset Run'));
+        assert.ok(openedContent.includes('# Destructive: Yes'));
+        assert.ok(openedContent.endsWith(`${buildVivadoResetRunTcl(project, run)}\n`));
+    });
+
     test('opens the only valid action without showing a quick pick', async () => {
         const project = makeProject();
         const run = project.runs[0];
@@ -214,6 +247,7 @@ suite('previewVivadoGeneratedTcl', () => {
         let openedContent = '';
 
         const result = await previewVivadoGeneratedTcl({ project, run }, {
+            actionDefinitions: [vivadoBuildTclActionDefinitions[0]],
             dependencies: makePreviewDependencies({
                 onQuickPick: () => {
                     quickPickCalled = true;

--- a/src/test/commands/vivado-reset-run.test.ts
+++ b/src/test/commands/vivado-reset-run.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for resetting selected Vivado runs through generated TCL.
+ * Covers the second implementation slice for #12.
+ */
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { vivadoTaskSource } from '../../constants';
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoRun, VivadoRunStatus, VivadoRunType } from '../../models/vivado-run';
+import resetVivadoRun, {
+    buildVivadoResetRunTaskName,
+    buildVivadoResetRunTcl,
+    resetVivadoRunCommandId,
+    resolveResetRunTarget,
+} from '../../commands/vivado/reset-run';
+import { quoteTclString } from '../../utils/vivado-tcl';
+
+function makeProject(runs: VivadoRun[] = [makeSynthesisRun('synth_1'), makeImplementationRun('impl_1')]): VivadoProject {
+    return new VivadoProject({
+        name: 'demo',
+        uri: vscode.Uri.file('/workspace/demo'),
+        xprFile: vscode.Uri.file('/workspace/demo/demo.xpr'),
+        runs,
+    });
+}
+
+function makeSynthesisRun(name: string): VivadoRun {
+    return new VivadoRun({
+        name,
+        type: VivadoRunType.Synthesis,
+        status: VivadoRunStatus.Complete,
+    });
+}
+
+function makeImplementationRun(name: string): VivadoRun {
+    return new VivadoRun({
+        name,
+        type: VivadoRunType.Implementation,
+        status: VivadoRunStatus.Complete,
+        parentRunName: 'synth_1',
+    });
+}
+
+function makeOtherRun(name: string): VivadoRun {
+    return new VivadoRun({
+        name,
+        type: VivadoRunType.Other,
+        status: VivadoRunStatus.Complete,
+    });
+}
+
+function makeVivadoTaskExecution(): vscode.TaskExecution {
+    const task = new vscode.Task(
+        { type: 'shell' },
+        vscode.TaskScope.Workspace,
+        'busy',
+        vivadoTaskSource,
+        new vscode.ShellExecution('vivado -mode batch'),
+    );
+
+    return { task } as vscode.TaskExecution;
+}
+
+suite('Vivado reset run TCL generation', () => {
+    test('builds project-mode TCL for the selected run', () => {
+        const project = makeProject();
+        const run = project.runs[0];
+
+        assert.strictEqual(
+            buildVivadoResetRunTcl(project, run),
+            [
+                `open_project ${quoteTclString(project.xprFile.fsPath)}`,
+                `set selected_run [get_runs ${quoteTclString(run.name)}]`,
+                'if {[llength $selected_run] != 1} {',
+                `    error ${quoteTclString(`Expected exactly one Vivado run named ${run.name}`)}`,
+                '}',
+                'reset_runs $selected_run',
+                'close_project',
+            ].join('\n'),
+        );
+    });
+
+    test('builds stable task names from the project and run', () => {
+        const project = makeProject();
+
+        assert.strictEqual(
+            buildVivadoResetRunTaskName(project, project.runs[0]),
+            'Vivado: Reset Run demo/synth_1',
+        );
+    });
+});
+
+suite('Vivado reset run target resolution', () => {
+    test('accepts an explicit synthesis run target', () => {
+        const project = makeProject();
+        const run = project.runs[0];
+
+        assert.deepStrictEqual(resolveResetRunTarget({ project, run }), { project, run });
+    });
+
+    test('accepts an explicit implementation run target', () => {
+        const project = makeProject();
+        const run = project.runs[1];
+
+        assert.deepStrictEqual(resolveResetRunTarget({ project, run }), { project, run });
+    });
+
+    test('rejects project-only targets', () => {
+        const project = makeProject();
+
+        assert.throws(
+            () => resolveResetRunTarget(project),
+            /Select a synthesis or implementation run/,
+        );
+    });
+
+    test('rejects targets without an explicit run', () => {
+        const project = makeProject();
+
+        assert.throws(
+            () => resolveResetRunTarget({ project }),
+            /Select a synthesis or implementation run/,
+        );
+    });
+
+    test('rejects unsupported run types', () => {
+        const project = makeProject([makeOtherRun('other_1')]);
+
+        assert.throws(
+            () => resolveResetRunTarget({ project, run: project.runs[0] }),
+            /Select a synthesis or implementation run/,
+        );
+    });
+});
+
+suite('resetVivadoRun', () => {
+    test('confirms, runs generated TCL through vivadoRun, and refreshes after success', async () => {
+        const project = makeProject();
+        const run = project.runs[0];
+        let capturedTcl = '';
+        let capturedTaskName = '';
+        let capturedStartPath: vscode.Uri | undefined;
+        let confirmMessage = '';
+        let confirmDetail: string | undefined;
+        let confirmLabel = '';
+        let infoMessage = '';
+        let refreshed = false;
+
+        const result = await resetVivadoRun({ project, run }, {
+            dependencies: {
+                vivadoRun: async (startPath, tcl, taskName) => {
+                    capturedStartPath = startPath;
+                    capturedTcl = tcl;
+                    capturedTaskName = taskName;
+                    return 0;
+                },
+                showWarningMessage: async (message, options, label) => {
+                    confirmMessage = message;
+                    confirmDetail = options.detail;
+                    confirmLabel = label;
+                    return label;
+                },
+                showInformationMessage: async message => {
+                    infoMessage = message;
+                    return undefined;
+                },
+                showErrorMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, true);
+        assert.strictEqual(confirmMessage, 'Reset Vivado run "synth_1" in "demo"?');
+        assert.strictEqual(confirmDetail, 'This resets the run state and may invalidate downstream results.');
+        assert.strictEqual(confirmLabel, 'Reset Run');
+        assert.strictEqual(capturedStartPath?.fsPath, project.uri.fsPath);
+        assert.strictEqual(capturedTaskName, buildVivadoResetRunTaskName(project, run));
+        assert.strictEqual(capturedTcl, buildVivadoResetRunTcl(project, run));
+        assert.ok(infoMessage.includes('Vivado reset run completed'));
+        assert.strictEqual(refreshed, true);
+    });
+
+    test('returns without generating TCL when confirmation is canceled', async () => {
+        const project = makeProject();
+        const run = project.runs[0];
+        let vivadoRunCalled = false;
+        let refreshed = false;
+
+        const result = await resetVivadoRun({ project, run }, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showWarningMessage: async () => undefined,
+                showInformationMessage: async () => undefined,
+                showErrorMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(vivadoRunCalled, false);
+        assert.strictEqual(refreshed, false);
+    });
+
+    test('rejects project targets before confirmation or TCL generation', async () => {
+        const project = makeProject();
+        let errorMessage = '';
+        let warningShown = false;
+        let vivadoRunCalled = false;
+
+        const result = await resetVivadoRun(project, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showWarningMessage: async () => {
+                    warningShown = true;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.ok(errorMessage.includes('Select a synthesis or implementation run'));
+        assert.strictEqual(warningShown, false);
+        assert.strictEqual(vivadoRunCalled, false);
+    });
+
+    test('rejects concurrent Vivado tasks before confirmation or TCL generation', async () => {
+        const project = makeProject();
+        const run = project.runs[0];
+        let errorMessage = '';
+        let warningShown = false;
+        let vivadoRunCalled = false;
+
+        const result = await resetVivadoRun({ project, run }, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showWarningMessage: async () => {
+                    warningShown = true;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                getTaskExecutions: () => [makeVivadoTaskExecution()],
+                refreshVivadoProjects: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(warningShown, false);
+        assert.strictEqual(vivadoRunCalled, false);
+        assert.ok(errorMessage.includes('already running'));
+    });
+
+    test('reports nonzero Vivado exits without refreshing', async () => {
+        const project = makeProject();
+        const run = project.runs[1];
+        let errorMessage = '';
+        let refreshed = false;
+
+        const result = await resetVivadoRun({ project, run }, {
+            dependencies: {
+                vivadoRun: async () => 1,
+                showWarningMessage: async (_message, _options, label) => label,
+                showInformationMessage: async () => undefined,
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.ok(errorMessage.includes('Vivado reset run failed'));
+        assert.strictEqual(refreshed, false);
+    });
+
+    test('treats undefined Vivado exits as canceled without refreshing', async () => {
+        const project = makeProject();
+        const run = project.runs[0];
+        let infoShown = false;
+        let errorShown = false;
+        let refreshed = false;
+
+        const result = await resetVivadoRun({ project, run }, {
+            dependencies: {
+                vivadoRun: async () => undefined,
+                showWarningMessage: async (_message, _options, label) => label,
+                showInformationMessage: async () => {
+                    infoShown = true;
+                    return undefined;
+                },
+                showErrorMessage: async () => {
+                    errorShown = true;
+                    return undefined;
+                },
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(infoShown, false);
+        assert.strictEqual(errorShown, false);
+        assert.strictEqual(refreshed, false);
+    });
+});
+
+suite('Vivado reset run package contribution', () => {
+    test('contributes Reset Run only to synthesis and implementation run tree items', () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const pkg = require('../../../package.json');
+        const command = pkg.contributes.commands.find((entry: { command: string }) => entry.command === resetVivadoRunCommandId);
+        const paletteEntry = pkg.contributes.menus.commandPalette.find((entry: { command: string }) => entry.command === resetVivadoRunCommandId);
+        const contextEntries = pkg.contributes.menus['view/item/context'].filter((entry: { command: string }) => entry.command === resetVivadoRunCommandId);
+
+        assert.strictEqual(command.title, 'Reset Run');
+        assert.strictEqual(paletteEntry.when, 'false');
+        assert.deepStrictEqual(
+            contextEntries.map((entry: { when: string }) => entry.when).sort(),
+            [
+                'view == projectsView && viewItem == vivadoImplementationRunItem',
+                'view == projectsView && viewItem == vivadoSynthesisRunItem',
+            ],
+        );
+    });
+});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -8,6 +8,7 @@ import * as ext from '../extension';
 import { generateVivadoBitstreamCommandId } from '../commands/vivado/generate-bitstream';
 import { openVivadoProjectCommandId } from '../commands/vivado/open-project';
 import { previewVivadoGeneratedTclCommandId } from '../commands/vivado/preview-generated-tcl';
+import { resetVivadoRunCommandId } from '../commands/vivado/reset-run';
 import { runVivadoImplementationCommandId } from '../commands/vivado/run-implementation';
 import { runVivadoSynthesisCommandId } from '../commands/vivado/run-synthesis';
 
@@ -135,6 +136,7 @@ suite('Extension activation', () => {
 
         assert.ok(registeredCommands.includes(openVivadoProjectCommandId));
         assert.ok(registeredCommands.includes(previewVivadoGeneratedTclCommandId));
+        assert.ok(registeredCommands.includes(resetVivadoRunCommandId));
         assert.ok(registeredCommands.includes(runVivadoSynthesisCommandId));
         assert.ok(registeredCommands.includes(runVivadoImplementationCommandId));
         assert.ok(registeredCommands.includes(generateVivadoBitstreamCommandId));


### PR DESCRIPTION
## Summary
- Add Reset Run for explicit Vivado synthesis and implementation run targets.
- Reuse the shared Vivado TCL action registry so reset can be previewed before execution.
- Add modal confirmation support to shared Vivado run command execution.
- Wire Reset Run into activation and supported run context menus only.
- Add focused tests for reset TCL, target rejection, confirmation, cancellation, active-task guarding, package contributions, and preview filtering.

## Validation
- git diff --check
- npm run compile
- npm run lint
- npm test
- Real Vivado 2021.2 reset probe on scratch project: synth_1 and impl_1 reset to Not started/0%

Refs #12