### PR TITLE
feat: add guarded Vivado clean run outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,11 @@
         "icon": "$(discard)"
       },
       {
+        "command": "vscode-vivado.projects.cleanRunOutputs",
+        "title": "Clean Run Outputs",
+        "icon": "$(trash)"
+      },
+      {
         "command": "vscode-vivado.projects.runSynthesis",
         "title": "Run Synthesis",
         "icon": "$(debug-start)"
@@ -205,6 +210,10 @@
         },
         {
           "command": "vscode-vivado.projects.resetRun",
+          "when": "false"
+        },
+        {
+          "command": "vscode-vivado.projects.cleanRunOutputs",
           "when": "false"
         },
         {
@@ -279,6 +288,11 @@
           "group": "inline@2"
         },
         {
+          "command": "vscode-vivado.projects.cleanRunOutputs",
+          "when": "view == projectsView && viewItem == vivadoSynthesisRunItem",
+          "group": "inline@3"
+        },
+        {
           "command": "vscode-vivado.projects.runImplementation",
           "when": "view == projectsView && viewItem == vivadoProjectItem",
           "group": "inline@2"
@@ -307,6 +321,11 @@
           "command": "vscode-vivado.projects.resetRun",
           "when": "view == projectsView && viewItem == vivadoImplementationRunItem",
           "group": "inline@3"
+        },
+        {
+          "command": "vscode-vivado.projects.cleanRunOutputs",
+          "when": "view == projectsView && viewItem == vivadoImplementationRunItem",
+          "group": "inline@4"
         }
       ]
     },

--- a/src/commands/vivado/clean-run-outputs.ts
+++ b/src/commands/vivado/clean-run-outputs.ts
@@ -1,0 +1,96 @@
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoRun, VivadoRunType } from '../../models/vivado-run';
+import { quoteTclString } from '../../utils/vivado-tcl';
+import {
+    buildVivadoRunTaskName,
+    ResolvedVivadoRunCommand,
+    resolveVivadoRunTarget,
+    RunVivadoCommandDependencies,
+    RunVivadoCommandOptions,
+    runVivadoProjectCommand,
+    VivadoRunCommandDefinition,
+    VivadoRunCommandTarget,
+} from './run-command';
+
+const commandId = 'vscode-vivado.projects.cleanRunOutputs';
+
+export type CleanVivadoRunOutputsDependencies = RunVivadoCommandDependencies;
+export type CleanVivadoRunOutputsOptions = RunVivadoCommandOptions;
+
+export const vivadoCleanRunOutputsActionDefinition: VivadoRunCommandDefinition = {
+    actionId: 'cleanRunOutputs',
+    title: 'Clean Run Outputs',
+    actionName: 'clean run outputs',
+    taskActionName: 'Clean Run Outputs',
+    runType: VivadoRunType.Synthesis,
+    runTypes: [VivadoRunType.Synthesis, VivadoRunType.Implementation],
+    runDescription: 'synthesis or implementation',
+    defaultRunName: 'synth_1',
+    supportsProjectTarget: false,
+    supportsRunTarget: true,
+    destructive: true,
+    confirmation: (project, run) => ({
+        message: `Clean generated outputs for Vivado run "${run.name}" in "${project.name}"?`,
+        detail: 'This resets the run and deletes only the Vivado-reported run directory after path guards pass.',
+        confirmLabel: 'Clean Run Outputs',
+    }),
+    buildTcl: buildVivadoCleanRunOutputsTcl,
+};
+
+export default async function cleanVivadoRunOutputs(
+    target: VivadoProject | VivadoRunCommandTarget | undefined,
+    options: CleanVivadoRunOutputsOptions = {},
+): Promise<boolean> {
+    return runVivadoProjectCommand(target, vivadoCleanRunOutputsActionDefinition, options);
+}
+
+export function buildVivadoCleanRunOutputsTcl(project: VivadoProject, run: VivadoRun): string {
+    const projectPath = quoteTclString(project.xprFile.fsPath);
+    const projectRoot = quoteTclString(project.uri.fsPath);
+    const runName = quoteTclString(run.name);
+
+    return [
+        `open_project ${projectPath}`,
+        `set selected_run [get_runs ${runName}]`,
+        'if {[llength $selected_run] != 1} {',
+        `    error ${quoteTclString(`Expected exactly one Vivado run named ${run.name}`)}`,
+        '}',
+        '',
+        `set project_root [file normalize ${projectRoot}]`,
+        'set run_dir_property [get_property DIRECTORY $selected_run]',
+        'if {$run_dir_property eq ""} {',
+        `    error ${quoteTclString(`Vivado did not report a run directory for ${run.name}`)}`,
+        '}',
+        'set run_dir [file normalize $run_dir_property]',
+        '',
+        'if {$run_dir eq $project_root} {',
+        `    error ${quoteTclString('Refusing to delete the project root')}`,
+        '}',
+        '',
+        'set project_parts [file split $project_root]',
+        'set run_parts [file split $run_dir]',
+        'set prefix [lrange $run_parts 0 [expr {[llength $project_parts] - 1}]]',
+        '',
+        'if {[llength $run_parts] <= [llength $project_parts] || $prefix ne $project_parts} {',
+        '    error "Refusing to delete a run directory outside the project root: $run_dir"',
+        '}',
+        '',
+        'reset_runs $selected_run',
+        '',
+        'if {[file exists $run_dir]} {',
+        '    file delete -force -- $run_dir',
+        '}',
+        '',
+        'close_project',
+    ].join('\n');
+}
+
+export function buildVivadoCleanRunOutputsTaskName(project: VivadoProject, run: VivadoRun): string {
+    return buildVivadoRunTaskName(vivadoCleanRunOutputsActionDefinition.taskActionName, project, run);
+}
+
+export function resolveCleanRunOutputsTarget(target: VivadoProject | VivadoRunCommandTarget | undefined): ResolvedVivadoRunCommand {
+    return resolveVivadoRunTarget(target, vivadoCleanRunOutputsActionDefinition);
+}
+
+export { commandId as cleanVivadoRunOutputsCommandId };

--- a/src/commands/vivado/tcl-actions.ts
+++ b/src/commands/vivado/tcl-actions.ts
@@ -1,4 +1,5 @@
 import { vivadoBitstreamActionDefinition } from './generate-bitstream';
+import { vivadoCleanRunOutputsActionDefinition } from './clean-run-outputs';
 import { VivadoTclActionDefinition } from './run-command';
 import { vivadoImplementationActionDefinition } from './run-implementation';
 import { vivadoResetRunActionDefinition } from './reset-run';
@@ -12,6 +13,7 @@ export const vivadoBuildTclActionDefinitions: readonly VivadoTclActionDefinition
 
 export const vivadoRunMaintenanceTclActionDefinitions: readonly VivadoTclActionDefinition[] = [
     vivadoResetRunActionDefinition,
+    vivadoCleanRunOutputsActionDefinition,
 ];
 
 export const vivadoTclActionDefinitions: readonly VivadoTclActionDefinition[] = [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import stopCosim from './commands/project/run/projects-stop-cosim';
 import stopCsim from './commands/project/run/projects-stop-csim';
 import stopCsynth from './commands/project/run/projects-stop-csynth';
 import generateVivadoBitstream, { generateVivadoBitstreamCommandId } from './commands/vivado/generate-bitstream';
+import cleanVivadoRunOutputs, { cleanVivadoRunOutputsCommandId } from './commands/vivado/clean-run-outputs';
 import openVivadoProject, { openVivadoProjectCommandId } from './commands/vivado/open-project';
 import previewVivadoGeneratedTcl, { previewVivadoGeneratedTclCommandId } from './commands/vivado/preview-generated-tcl';
 import resetVivadoRun, { resetVivadoRunCommandId } from './commands/vivado/reset-run';
@@ -50,6 +51,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand(openVivadoProjectCommandId, (e?: VivadoProjectTreeItem) => openVivadoProject(e?.project)),
 		vscode.commands.registerCommand(previewVivadoGeneratedTclCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => previewVivadoGeneratedTcl(e)),
 		vscode.commands.registerCommand(resetVivadoRunCommandId, (e?: VivadoRunTreeItem) => resetVivadoRun(e)),
+		vscode.commands.registerCommand(cleanVivadoRunOutputsCommandId, (e?: VivadoRunTreeItem) => cleanVivadoRunOutputs(e)),
 		vscode.commands.registerCommand(runVivadoSynthesisCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => runVivadoSynthesis(e)),
 		vscode.commands.registerCommand(runVivadoImplementationCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => runVivadoImplementation(e)),
 		vscode.commands.registerCommand(generateVivadoBitstreamCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => generateVivadoBitstream(e)),

--- a/src/test/commands/vivado-clean-run-outputs.test.ts
+++ b/src/test/commands/vivado-clean-run-outputs.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Tests for cleaning generated outputs for selected Vivado runs.
+ * Covers the guarded clean implementation slice for #12.
+ */
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import cleanVivadoRunOutputs, {
+    buildVivadoCleanRunOutputsTaskName,
+    buildVivadoCleanRunOutputsTcl,
+    cleanVivadoRunOutputsCommandId,
+    resolveCleanRunOutputsTarget,
+} from '../../commands/vivado/clean-run-outputs';
+import { vivadoTaskSource } from '../../constants';
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoRun, VivadoRunStatus, VivadoRunType } from '../../models/vivado-run';
+import { quoteTclString } from '../../utils/vivado-tcl';
+
+function makeProject(runs: VivadoRun[] = [makeSynthesisRun('synth_1'), makeImplementationRun('impl_1')]): VivadoProject {
+    return new VivadoProject({
+        name: 'demo',
+        uri: vscode.Uri.file('/workspace/demo'),
+        xprFile: vscode.Uri.file('/workspace/demo/demo.xpr'),
+        runs,
+    });
+}
+
+function makeSynthesisRun(name: string): VivadoRun {
+    return new VivadoRun({
+        name,
+        type: VivadoRunType.Synthesis,
+        status: VivadoRunStatus.Complete,
+    });
+}
+
+function makeImplementationRun(name: string): VivadoRun {
+    return new VivadoRun({
+        name,
+        type: VivadoRunType.Implementation,
+        status: VivadoRunStatus.Complete,
+        parentRunName: 'synth_1',
+    });
+}
+
+function makeOtherRun(name: string): VivadoRun {
+    return new VivadoRun({
+        name,
+        type: VivadoRunType.Other,
+        status: VivadoRunStatus.Complete,
+    });
+}
+
+function makeVivadoTaskExecution(): vscode.TaskExecution {
+    const task = new vscode.Task(
+        { type: 'shell' },
+        vscode.TaskScope.Workspace,
+        'busy',
+        vivadoTaskSource,
+        new vscode.ShellExecution('vivado -mode batch'),
+    );
+
+    return { task } as vscode.TaskExecution;
+}
+
+suite('Vivado clean run outputs TCL generation', () => {
+    test('builds guarded project-mode TCL for the selected run', () => {
+        const project = makeProject();
+        const run = project.runs[0];
+        const tcl = buildVivadoCleanRunOutputsTcl(project, run);
+
+        assert.strictEqual(
+            tcl,
+            [
+                `open_project ${quoteTclString(project.xprFile.fsPath)}`,
+                `set selected_run [get_runs ${quoteTclString(run.name)}]`,
+                'if {[llength $selected_run] != 1} {',
+                `    error ${quoteTclString(`Expected exactly one Vivado run named ${run.name}`)}`,
+                '}',
+                '',
+                `set project_root [file normalize ${quoteTclString(project.uri.fsPath)}]`,
+                'set run_dir_property [get_property DIRECTORY $selected_run]',
+                'if {$run_dir_property eq ""} {',
+                `    error ${quoteTclString(`Vivado did not report a run directory for ${run.name}`)}`,
+                '}',
+                'set run_dir [file normalize $run_dir_property]',
+                '',
+                'if {$run_dir eq $project_root} {',
+                `    error ${quoteTclString('Refusing to delete the project root')}`,
+                '}',
+                '',
+                'set project_parts [file split $project_root]',
+                'set run_parts [file split $run_dir]',
+                'set prefix [lrange $run_parts 0 [expr {[llength $project_parts] - 1}]]',
+                '',
+                'if {[llength $run_parts] <= [llength $project_parts] || $prefix ne $project_parts} {',
+                '    error "Refusing to delete a run directory outside the project root: $run_dir"',
+                '}',
+                '',
+                'reset_runs $selected_run',
+                '',
+                'if {[file exists $run_dir]} {',
+                '    file delete -force -- $run_dir',
+                '}',
+                '',
+                'close_project',
+            ].join('\n'),
+        );
+        assert.ok(!tcl.includes('delete_runs'));
+        assert.ok(!tcl.includes('reset_project'));
+    });
+
+    test('builds stable task names from the project and run', () => {
+        const project = makeProject();
+
+        assert.strictEqual(
+            buildVivadoCleanRunOutputsTaskName(project, project.runs[0]),
+            'Vivado: Clean Run Outputs demo/synth_1',
+        );
+    });
+});
+
+suite('Vivado clean run outputs target resolution', () => {
+    test('accepts an explicit synthesis run target', () => {
+        const project = makeProject();
+        const run = project.runs[0];
+
+        assert.deepStrictEqual(resolveCleanRunOutputsTarget({ project, run }), { project, run });
+    });
+
+    test('accepts an explicit implementation run target', () => {
+        const project = makeProject();
+        const run = project.runs[1];
+
+        assert.deepStrictEqual(resolveCleanRunOutputsTarget({ project, run }), { project, run });
+    });
+
+    test('rejects project-only targets', () => {
+        const project = makeProject();
+
+        assert.throws(
+            () => resolveCleanRunOutputsTarget(project),
+            /Select a synthesis or implementation run/,
+        );
+    });
+
+    test('rejects targets without an explicit run', () => {
+        const project = makeProject();
+
+        assert.throws(
+            () => resolveCleanRunOutputsTarget({ project }),
+            /Select a synthesis or implementation run/,
+        );
+    });
+
+    test('rejects unsupported run types', () => {
+        const project = makeProject([makeOtherRun('other_1')]);
+
+        assert.throws(
+            () => resolveCleanRunOutputsTarget({ project, run: project.runs[0] }),
+            /Select a synthesis or implementation run/,
+        );
+    });
+});
+
+suite('cleanVivadoRunOutputs', () => {
+    test('confirms, runs generated TCL through vivadoRun, and refreshes after success', async () => {
+        const project = makeProject();
+        const run = project.runs[0];
+        let capturedTcl = '';
+        let capturedTaskName = '';
+        let capturedStartPath: vscode.Uri | undefined;
+        let confirmMessage = '';
+        let confirmDetail: string | undefined;
+        let confirmLabel = '';
+        let infoMessage = '';
+        let refreshed = false;
+
+        const result = await cleanVivadoRunOutputs({ project, run }, {
+            dependencies: {
+                vivadoRun: async (startPath, tcl, taskName) => {
+                    capturedStartPath = startPath;
+                    capturedTcl = tcl;
+                    capturedTaskName = taskName;
+                    return 0;
+                },
+                showWarningMessage: async (message, options, label) => {
+                    confirmMessage = message;
+                    confirmDetail = options.detail;
+                    confirmLabel = label;
+                    return label;
+                },
+                showInformationMessage: async message => {
+                    infoMessage = message;
+                    return undefined;
+                },
+                showErrorMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, true);
+        assert.strictEqual(confirmMessage, 'Clean generated outputs for Vivado run "synth_1" in "demo"?');
+        assert.strictEqual(
+            confirmDetail,
+            'This resets the run and deletes only the Vivado-reported run directory after path guards pass.',
+        );
+        assert.strictEqual(confirmLabel, 'Clean Run Outputs');
+        assert.strictEqual(capturedStartPath?.fsPath, project.uri.fsPath);
+        assert.strictEqual(capturedTaskName, buildVivadoCleanRunOutputsTaskName(project, run));
+        assert.strictEqual(capturedTcl, buildVivadoCleanRunOutputsTcl(project, run));
+        assert.ok(infoMessage.includes('Vivado clean run outputs completed'));
+        assert.strictEqual(refreshed, true);
+    });
+
+    test('returns without generating TCL when confirmation is canceled', async () => {
+        const project = makeProject();
+        const run = project.runs[0];
+        let vivadoRunCalled = false;
+        let refreshed = false;
+
+        const result = await cleanVivadoRunOutputs({ project, run }, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showWarningMessage: async () => undefined,
+                showInformationMessage: async () => undefined,
+                showErrorMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(vivadoRunCalled, false);
+        assert.strictEqual(refreshed, false);
+    });
+
+    test('rejects project targets before confirmation or TCL generation', async () => {
+        const project = makeProject();
+        let errorMessage = '';
+        let warningShown = false;
+        let vivadoRunCalled = false;
+
+        const result = await cleanVivadoRunOutputs(project, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showWarningMessage: async () => {
+                    warningShown = true;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.ok(errorMessage.includes('Select a synthesis or implementation run'));
+        assert.strictEqual(warningShown, false);
+        assert.strictEqual(vivadoRunCalled, false);
+    });
+
+    test('rejects concurrent Vivado tasks before confirmation or TCL generation', async () => {
+        const project = makeProject();
+        const run = project.runs[0];
+        let errorMessage = '';
+        let warningShown = false;
+        let vivadoRunCalled = false;
+
+        const result = await cleanVivadoRunOutputs({ project, run }, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showWarningMessage: async () => {
+                    warningShown = true;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                getTaskExecutions: () => [makeVivadoTaskExecution()],
+                refreshVivadoProjects: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(warningShown, false);
+        assert.strictEqual(vivadoRunCalled, false);
+        assert.ok(errorMessage.includes('already running'));
+    });
+
+    test('reports nonzero Vivado exits without refreshing', async () => {
+        const project = makeProject();
+        const run = project.runs[1];
+        let errorMessage = '';
+        let refreshed = false;
+
+        const result = await cleanVivadoRunOutputs({ project, run }, {
+            dependencies: {
+                vivadoRun: async () => 1,
+                showWarningMessage: async (_message, _options, label) => label,
+                showInformationMessage: async () => undefined,
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.ok(errorMessage.includes('Vivado clean run outputs failed'));
+        assert.strictEqual(refreshed, false);
+    });
+
+    test('treats undefined Vivado exits as canceled without refreshing', async () => {
+        const project = makeProject();
+        const run = project.runs[0];
+        let infoShown = false;
+        let errorShown = false;
+        let refreshed = false;
+
+        const result = await cleanVivadoRunOutputs({ project, run }, {
+            dependencies: {
+                vivadoRun: async () => undefined,
+                showWarningMessage: async (_message, _options, label) => label,
+                showInformationMessage: async () => {
+                    infoShown = true;
+                    return undefined;
+                },
+                showErrorMessage: async () => {
+                    errorShown = true;
+                    return undefined;
+                },
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(infoShown, false);
+        assert.strictEqual(errorShown, false);
+        assert.strictEqual(refreshed, false);
+    });
+});
+
+suite('Vivado clean run outputs package contribution', () => {
+    test('contributes Clean Run Outputs only to synthesis and implementation run tree items', () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const pkg = require('../../../package.json');
+        const command = pkg.contributes.commands.find((entry: { command: string }) => entry.command === cleanVivadoRunOutputsCommandId);
+        const paletteEntry = pkg.contributes.menus.commandPalette.find((entry: { command: string }) => entry.command === cleanVivadoRunOutputsCommandId);
+        const contextEntries = pkg.contributes.menus['view/item/context'].filter((entry: { command: string }) => entry.command === cleanVivadoRunOutputsCommandId);
+
+        assert.strictEqual(command.title, 'Clean Run Outputs');
+        assert.strictEqual(command.icon, '$(trash)');
+        assert.strictEqual(paletteEntry.when, 'false');
+        assert.deepStrictEqual(
+            contextEntries.map((entry: { when: string }) => entry.when).sort(),
+            [
+                'view == projectsView && viewItem == vivadoImplementationRunItem',
+                'view == projectsView && viewItem == vivadoSynthesisRunItem',
+            ],
+        );
+    });
+});

--- a/src/test/commands/vivado-preview-generated-tcl.test.ts
+++ b/src/test/commands/vivado-preview-generated-tcl.test.ts
@@ -4,6 +4,7 @@
  */
 import * as assert from 'assert';
 import * as vscode from 'vscode';
+import { buildVivadoCleanRunOutputsTcl } from '../../commands/vivado/clean-run-outputs';
 import { buildVivadoBitstreamTcl, vivadoBitstreamActionDefinition } from '../../commands/vivado/generate-bitstream';
 import previewVivadoGeneratedTcl, {
     buildVivadoTclPreviewContent,
@@ -95,10 +96,10 @@ suite('Vivado generated TCL preview action registry', () => {
         );
     });
 
-    test('contains reset after the current build actions in preview order', () => {
+    test('contains run maintenance actions after the current build actions in preview order', () => {
         assert.deepStrictEqual(
             vivadoTclActionDefinitions.map(action => action.title),
-            ['Run Synthesis', 'Run Implementation', 'Generate Bitstream', 'Reset Run'],
+            ['Run Synthesis', 'Run Implementation', 'Generate Bitstream', 'Reset Run', 'Clean Run Outputs'],
         );
     });
 });
@@ -123,17 +124,17 @@ suite('Vivado generated TCL preview action resolution', () => {
 
         assert.deepStrictEqual(
             resolveVivadoTclPreviewActions({ project, run }).map(action => action.definition.title),
-            ['Run Synthesis', 'Reset Run'],
+            ['Run Synthesis', 'Reset Run', 'Clean Run Outputs'],
         );
     });
 
-    test('offers implementation, bitstream, and reset actions for an explicit implementation run target', () => {
+    test('offers implementation, bitstream, and maintenance actions for an explicit implementation run target', () => {
         const project = makeProject();
         const run = project.runs[1];
 
         assert.deepStrictEqual(
             resolveVivadoTclPreviewActions({ project, run }).map(action => action.definition.title),
-            ['Run Implementation', 'Generate Bitstream', 'Reset Run'],
+            ['Run Implementation', 'Generate Bitstream', 'Reset Run', 'Clean Run Outputs'],
         );
     });
 
@@ -234,10 +235,35 @@ suite('previewVivadoGeneratedTcl', () => {
         });
 
         assert.strictEqual(result, true);
-        assert.deepStrictEqual(quickPickLabels, ['Run Synthesis', 'Reset Run']);
+        assert.deepStrictEqual(quickPickLabels, ['Run Synthesis', 'Reset Run', 'Clean Run Outputs']);
         assert.ok(openedContent.includes('# Action: Reset Run'));
         assert.ok(openedContent.includes('# Destructive: Yes'));
         assert.ok(openedContent.endsWith(`${buildVivadoResetRunTcl(project, run)}\n`));
+    });
+
+    test('opens clean run outputs from an explicit run quick pick', async () => {
+        const project = makeProject();
+        const run = project.runs[1];
+        let quickPickLabels: string[] = [];
+        let openedContent = '';
+
+        const result = await previewVivadoGeneratedTcl({ project, run }, {
+            dependencies: makePreviewDependencies({
+                pickTitle: 'Clean Run Outputs',
+                onQuickPick: items => {
+                    quickPickLabels = items.map(item => item.label);
+                },
+                onOpenTextDocument: options => {
+                    openedContent = options.content;
+                },
+            }),
+        });
+
+        assert.strictEqual(result, true);
+        assert.deepStrictEqual(quickPickLabels, ['Run Implementation', 'Generate Bitstream', 'Reset Run', 'Clean Run Outputs']);
+        assert.ok(openedContent.includes('# Action: Clean Run Outputs'));
+        assert.ok(openedContent.includes('# Destructive: Yes'));
+        assert.ok(openedContent.endsWith(`${buildVivadoCleanRunOutputsTcl(project, run)}\n`));
     });
 
     test('opens the only valid action without showing a quick pick', async () => {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -5,6 +5,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as ext from '../extension';
+import { cleanVivadoRunOutputsCommandId } from '../commands/vivado/clean-run-outputs';
 import { generateVivadoBitstreamCommandId } from '../commands/vivado/generate-bitstream';
 import { openVivadoProjectCommandId } from '../commands/vivado/open-project';
 import { previewVivadoGeneratedTclCommandId } from '../commands/vivado/preview-generated-tcl';
@@ -137,6 +138,7 @@ suite('Extension activation', () => {
         assert.ok(registeredCommands.includes(openVivadoProjectCommandId));
         assert.ok(registeredCommands.includes(previewVivadoGeneratedTclCommandId));
         assert.ok(registeredCommands.includes(resetVivadoRunCommandId));
+        assert.ok(registeredCommands.includes(cleanVivadoRunOutputsCommandId));
         assert.ok(registeredCommands.includes(runVivadoSynthesisCommandId));
         assert.ok(registeredCommands.includes(runVivadoImplementationCommandId));
         assert.ok(registeredCommands.includes(generateVivadoBitstreamCommandId));


### PR DESCRIPTION
## Summary
- add a destructive Clean Run Outputs command for synthesis and implementation run nodes
- generate guarded TCL that resolves Vivado's run DIRECTORY, refuses project-root or outside-project paths, resets the run, then deletes the reported run directory
- include the clean action in generated TCL preview and command/menu wiring

## Validation
- npm run compile
- npm run lint
- git diff --check
- npm test (261 passing)
- Vivado 2021.2 smoke: created a scratch project, ran synth_1 to 100%, executed the clean TCL, verified synth_1 reset to Not started/0% and the reported run directory no longer exists

Refs #12