### PR TITLE
docs: wrap Vivado run maintenance docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Vivado.
 ## Current HLS Support
 
 See [Features](docs/features.md) and [Getting Started](docs/getting-started.md)
-for the current user-facing workflow.
+for the current user-facing workflows.
 
 - Discover and manage multiple Vitis HLS projects from one workspace.
 - Browse HLS source files, test bench files, and solutions in the project tree.
@@ -25,6 +25,17 @@ for the current user-facing workflow.
 - Run C synthesis.
 - Run C/RTL cosimulation.
 - Add and remove source and test bench files.
+
+## Current Vivado Support
+
+- Discover Vivado projects from `.xpr` files.
+- Browse Vivado design sources, simulation sources, constraints, runs, and reports.
+- Open a project in the Vivado IDE.
+- Run synthesis, implementation, and bitstream generation as TCL-backed VS Code
+  tasks.
+- Preview generated TCL without executing Vivado.
+- Reset selected synthesis or implementation runs.
+- Clean generated outputs for selected synthesis or implementation runs.
 
 ## Vivado Direction
 
@@ -46,13 +57,11 @@ path. The intended direction is:
 
 ## Requirements
 
-For the current HLS workflow, see [Getting Started](docs/getting-started.md)
-for setup details.
+For setup details, see [Getting Started](docs/getting-started.md).
 
 - [Vitis and Vitis HLS](https://www.xilinx.com/support/download.html)
+- [Vivado](https://www.xilinx.com/support/download.html)
 - The Microsoft C/C++ extension when using C simulation debugging
-
-Vivado-specific requirements will be documented as Vivado support lands.
 
 ## Extension Settings
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,9 +34,10 @@ npm run lint
 
 Use the `Run Extension` launch configuration in VS Code. It compiles the extension and opens a new Extension Development Host window.
 
-Open a workspace containing an `hls.app` file to activate the current implementation.
+Open a workspace containing an `hls.app` file or a `.xpr` file to activate the
+current implementation.
 
-For Vivado support work, use a fixture workspace with a small `.xpr` project once `.xpr` activation and parsing are added.
+For Vivado support work, use a fixture workspace with a small `.xpr` project.
 
 ## Vivado Development Direction
 
@@ -44,7 +45,7 @@ Prioritize changes in this order:
 
 - Read-only `.xpr` discovery and metadata parsing.
 - Tree provider changes for Vivado sources, constraints, IP, block designs, runs, and reports.
-- TCL-backed task creation for synthesis, implementation, bitstream, and simulation.
+- TCL-backed task creation for synthesis, implementation, bitstream, run maintenance, and simulation.
 - Problem matchers and diagnostics for Vivado messages.
 - Conservative project editing commands after parser and tree behavior are tested.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -119,6 +119,40 @@ project-mode implementation run. The command generates visible TCL that opens
 the `.xpr`, calls `launch_runs -to_step write_bitstream`, waits for the run,
 and checks that Vivado reports `PROGRESS` as `100%`.
 
+### Preview Generated TCL
+
+Use the `Preview Generated TCL` context action on a Vivado project node,
+synthesis run node, or implementation run node to inspect extension-generated
+TCL without launching Vivado. Project-level previews offer the build actions
+available for the project. Run-level previews also include run maintenance
+actions that are valid for that run.
+
+Preview documents are untitled TCL documents. They include a preview-only
+header, the selected project and run, and a destructive marker for reset and
+clean actions.
+
+### Reset Run
+
+Use the `Reset Run` context action on a synthesis or implementation run node to
+reset that selected Vivado run. The command requires modal confirmation before
+generating TCL or launching Vivado, rejects project-only targets, and refuses to
+start while another Vivado task is active.
+
+The generated TCL opens the `.xpr`, resolves the selected run with `get_runs`,
+calls `reset_runs`, and closes the project.
+
+### Clean Run Outputs
+
+Use the `Clean Run Outputs` context action on a synthesis or implementation run
+node to reset the selected run and delete only the Vivado-reported run output
+directory. The command requires modal confirmation before generating TCL or
+launching Vivado, rejects project-only targets, and refuses to start while
+another Vivado task is active.
+
+Before deleting anything, the generated TCL reads the run `DIRECTORY` property,
+normalizes it, rejects empty paths, rejects the project root, and rejects paths
+outside the project root.
+
 ## Planned Vivado Features
 
 The extension should grow from HLS project management into Vivado project support. The desired Vivado features are listed here as the product target.
@@ -156,8 +190,7 @@ Parse Vivado messages from task output and report files. Diagnostics should link
 ### TCL Workflow
 
 Support project-based and script-based flows. Users should be able to run
-checked-in TCL scripts, generate project summaries, and inspect the exact
-commands issued by the extension.
+checked-in TCL scripts and generate project summaries.
 
 ### HLS And Vivado Together
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,8 +40,18 @@ project tree with:
 - Reports.
 
 Use the `Open in Vivado` context action on a Vivado project node to launch the
-Vivado IDE with that `.xpr` project. Synthesis, implementation, bitstream,
-simulation, IP, block design, and hardware-manager commands are still under
+Vivado IDE with that `.xpr` project.
+
+Use the run context actions to:
+
+- preview generated TCL before execution,
+- run synthesis,
+- run implementation,
+- generate bitstreams,
+- reset selected synthesis or implementation runs,
+- clean generated outputs for selected synthesis or implementation runs.
+
+Simulation, IP, block design, and hardware-manager commands are still under
 development.
 
 ## Configure Tool Paths Today

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,14 @@
 
 VS Code Vivado is a Visual Studio Code extension project for bringing AMD Vivado workflows into the editor.
 
-The repository currently contains an inherited Vitis HLS extension baseline. That baseline discovers `hls.app` project files and provides project tree actions for source files, test bench files, C simulation, C synthesis, and C/RTL cosimulation.
+The repository started from an inherited Vitis HLS extension baseline. That baseline discovers `hls.app` project files and provides project tree actions for source files, test bench files, C simulation, C synthesis, and C/RTL cosimulation.
 
-The direction for this repository is broader Vivado project support: discovering Vivado projects, surfacing design sources and constraints, running common Vivado flows, and making project state visible inside VS Code.
+The current Vivado workflow discovers `.xpr` projects, surfaces sources, constraints, runs, and reports, and runs project-mode build and maintenance actions through visible TCL.
 
 !!! warning
-    The current implementation is still Vitis HLS-oriented. The Vivado support described in these docs is the desired direction unless a section is explicitly marked as current behavior.
+    Some Vivado sections describe the desired direction for future milestones. Sections marked as current behavior describe the shipped extension surface.
 
-## Current Baseline
+## Current Support
 
 - Discover Vitis HLS projects in a VS Code workspace.
 - Browse source and test bench files from the Projects tree.
@@ -18,12 +18,18 @@ The direction for this repository is broader Vivado project support: discovering
 - Run C synthesis.
 - Run C/RTL cosimulation.
 - Surface C simulation diagnostics through the contributed problem matcher.
+- Discover Vivado projects from `.xpr` files.
+- Browse Vivado design sources, simulation sources, constraints, runs, and reports.
+- Open Vivado projects in the Vivado IDE.
+- Run synthesis, implementation, and bitstream generation through visible TCL-backed tasks.
+- Preview generated TCL without executing Vivado.
+- Reset selected Vivado synthesis or implementation runs.
+- Clean generated outputs for selected Vivado synthesis or implementation runs.
 
 ## Desired Vivado Support
 
-- Discover Vivado projects from `.xpr` files.
 - Show RTL sources, block designs, constraints, simulation sources, IP, and generated outputs.
-- Run synthesis, implementation, bitstream generation, simulation, and reports from VS Code tasks.
+- Run simulation and report-generation flows from VS Code tasks.
 - Parse Vivado diagnostics and link messages back to source files.
 - Support TCL-first automation so the extension can mirror reproducible command-line flows.
 - Keep Vitis HLS support available where it helps FPGA projects that use both HLS and Vivado.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -146,10 +146,11 @@ Build the Vivado workflow in small, testable slices:
 4. Add `vivadoRun(...)` for Tcl-backed Vivado tasks.
 5. Render a minimal Vivado tree with sources, constraints, runs, and reports.
 6. Add commands for opening the Vivado GUI, running synthesis, running implementation, and generating a bitstream.
-7. Add diagnostics and report parsing.
-8. Add XSim simulation commands.
-9. Add IP and block design commands.
-10. Add hardware programming and debug commands.
+7. Add generated TCL preview plus reset and clean commands for selected runs.
+8. Add diagnostics and report parsing.
+9. Add XSim simulation commands.
+10. Add IP and block design commands.
+11. Add hardware programming and debug commands.
 
 ## Project Editing
 


### PR DESCRIPTION
## Summary
- document Preview Generated TCL, Reset Run, and Clean Run Outputs as current Vivado features
- update getting-started and docs home language so shipped Vivado support is no longer described as future-only
- adjust the roadmap implementation order to include the completed run maintenance slice

## Validation
- npm run docs:build
- git diff --check

Closes #12