### PR TITLE
Add Vivado problem matcher diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ for the current user-facing workflows.
 - Open a project in the Vivado IDE.
 - Run synthesis, implementation, and bitstream generation as TCL-backed VS Code
   tasks.
+- Surface file-backed Vivado task diagnostics in Problems when Vivado emits
+  file and line locations.
 - Preview generated TCL without executing Vivado.
 - Reset selected synthesis or implementation runs.
 - Clean generated outputs for selected synthesis or implementation runs.
@@ -51,7 +53,7 @@ path. The intended direction is:
 - Render a Vivado project tree for design sources, simulation sources,
   constraints, runs, reports, IP, block designs, TCL scripts, and hardware.
 - Run Vivado tasks through visible, reproducible TCL.
-- Surface Vivado diagnostics and report summaries inside VS Code.
+- Extend Vivado diagnostics and report summaries inside VS Code.
 - Add XSim, IP, block design, and hardware manager workflows after the project
   foundation is reliable.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -153,6 +153,16 @@ Before deleting anything, the generated TCL reads the run `DIRECTORY` property,
 normalizes it, rejects empty paths, rejects the project root, and rejects paths
 outside the project root.
 
+### Vivado Diagnostics
+
+Vivado tasks use a contributed problem matcher for file-backed `ERROR`,
+`WARNING`, `CRITICAL WARNING`, and `INFO` messages that end with
+`[file:line]` or `[file:line:column]`. Matching messages appear in Problems and
+link back to the emitted file location.
+
+Messages without usable file and line data remain in the task terminal and
+generated logs so they can still be searched and copied.
+
 ## Planned Vivado Features
 
 The extension should grow from HLS project management into Vivado project support. The desired Vivado features are listed here as the product target.
@@ -183,9 +193,10 @@ Expose common Vivado runs as VS Code commands and tasks:
 
 The extension should use Vivado TCL under the hood so every action can be reproduced outside VS Code.
 
-### Diagnostics
+### Report Diagnostics
 
-Parse Vivado messages from task output and report files. Diagnostics should link warnings and errors back to source files where possible.
+Parse Vivado report files and richer run artifacts into diagnostics and
+summaries after task-output matching is complete.
 
 ### TCL Workflow
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,8 @@ The current Vivado workflow discovers `.xpr` projects, surfaces sources, constra
 - Browse Vivado design sources, simulation sources, constraints, runs, and reports.
 - Open Vivado projects in the Vivado IDE.
 - Run synthesis, implementation, and bitstream generation through visible TCL-backed tasks.
+- Surface file-backed Vivado task diagnostics in Problems when Vivado emits
+  file and line locations.
 - Preview generated TCL without executing Vivado.
 - Reset selected Vivado synthesis or implementation runs.
 - Clean generated outputs for selected Vivado synthesis or implementation runs.
@@ -30,7 +32,7 @@ The current Vivado workflow discovers `.xpr` projects, surfaces sources, constra
 
 - Show RTL sources, block designs, constraints, simulation sources, IP, and generated outputs.
 - Run simulation and report-generation flows from VS Code tasks.
-- Parse Vivado diagnostics and link messages back to source files.
+- Extend Vivado report diagnostics and summaries.
 - Support TCL-first automation so the extension can mirror reproducible command-line flows.
 - Keep Vitis HLS support available where it helps FPGA projects that use both HLS and Vivado.
 

--- a/package.json
+++ b/package.json
@@ -344,6 +344,22 @@
             "message": 7
           }
         ]
+      },
+      {
+        "name": "vscode-vivado-vivado",
+        "owner": "vscode-vivado",
+        "fileLocation": "absolute",
+        "pattern": [
+          {
+            "regexp": "^(?:(CRITICAL)\\s+)?(ERROR|WARNING|INFO):\\s+\\[([^\\]]+)\\]\\s*(.*?)\\s+\\[(.+?):(\\d+)(?::(\\d+))?\\]\\s*$",
+            "severity": 2,
+            "code": 3,
+            "message": 4,
+            "file": 5,
+            "line": 6,
+            "column": 7
+          }
+        ]
       }
     ]
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
-
 export const taskSource = 'Vitis HLS IDE';
 export const vivadoTaskSource = 'VS Code Vivado';
+export const vivadoProblemMatcher = '$vscode-vivado-vivado';

--- a/src/test/fixtures/vivado-diagnostics.log
+++ b/src/test/fixtures/vivado-diagnostics.log
@@ -1,0 +1,7 @@
+INFO: [Vivado 12-4895] Creating project [/workspace/scripts/create_project.tcl:5]
+WARNING: [Synth 8-3331] design top has unconnected port [/workspace/src/top.sv:42]
+ERROR: [Place 30-574] Poor placement for routing between an IO pin and BUFG. [C:/work/fpga/constraints.xdc:17]
+CRITICAL WARNING: [Route 35-39] The design did not meet timing [/home/me/fpga/top.xdc:21:7]
+ERROR: [Timing 38-282] The design failed timing. [/workspace/reports/timing.rpt:103]
+ERROR: [DRC NSTD-1] Unspecified I/O Standard: 1 out of 1 logical ports use I/O standard Default.
+ERROR: [Vivado 12-1411] Cannot set LOC property of ports [led].

--- a/src/test/utils/vivado-diagnostics.test.ts
+++ b/src/test/utils/vivado-diagnostics.test.ts
@@ -1,0 +1,106 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    parseVivadoDiagnosticLine,
+    parseVivadoDiagnosticLines,
+    vivadoDiagnosticLinePattern,
+} from '../../utils/vivado-diagnostics';
+
+interface PackageProblemMatcher {
+    name: string;
+    owner: string;
+    fileLocation: string;
+    pattern: Array<{
+        regexp: string;
+        severity: number;
+        code: number;
+        message: number;
+        file: number;
+        line: number;
+        column: number;
+    }>;
+}
+
+function readFixtureLines(name: string): string[] {
+    const fixturePath = path.resolve(__dirname, '../../../src/test/fixtures', name);
+    return fs.readFileSync(fixturePath, 'utf8').trimEnd().split(/\r?\n/);
+}
+
+suite('Vivado diagnostics parsing', () => {
+    test('parses file-backed Vivado diagnostics from fixture output', () => {
+        const diagnostics = parseVivadoDiagnosticLines(readFixtureLines('vivado-diagnostics.log'));
+
+        assert.strictEqual(diagnostics.length, 5);
+        assert.deepStrictEqual(diagnostics[0], {
+            severity: 'info',
+            rawSeverity: 'INFO',
+            code: 'Vivado 12-4895',
+            message: 'Creating project',
+            filePath: '/workspace/scripts/create_project.tcl',
+            line: 5,
+            column: undefined,
+        });
+        assert.deepStrictEqual(diagnostics[2], {
+            severity: 'error',
+            rawSeverity: 'ERROR',
+            code: 'Place 30-574',
+            message: 'Poor placement for routing between an IO pin and BUFG.',
+            filePath: 'C:/work/fpga/constraints.xdc',
+            line: 17,
+            column: undefined,
+        });
+        assert.deepStrictEqual(diagnostics[3], {
+            severity: 'warning',
+            rawSeverity: 'CRITICAL WARNING',
+            code: 'Route 35-39',
+            message: 'The design did not meet timing',
+            filePath: '/home/me/fpga/top.xdc',
+            line: 21,
+            column: 7,
+        });
+    });
+
+    test('leaves non-file-specific Vivado messages unparsed', () => {
+        assert.strictEqual(
+            parseVivadoDiagnosticLine('ERROR: [DRC NSTD-1] Unspecified I/O Standard.'),
+            undefined,
+        );
+        assert.strictEqual(
+            parseVivadoDiagnosticLine('ERROR: [Vivado 12-1411] Cannot set LOC property of ports [led].'),
+            undefined,
+        );
+    });
+
+    test('rejects invalid file locations', () => {
+        assert.strictEqual(
+            parseVivadoDiagnosticLine('ERROR: [Synth 8-439] Invalid line [/workspace/src/top.sv:0]'),
+            undefined,
+        );
+        assert.strictEqual(
+            parseVivadoDiagnosticLine('WARNING: [Vivado 12-999] Invalid column [/workspace/top.xdc:3:0]'),
+            undefined,
+        );
+    });
+
+    test('package.json contributes the Vivado problem matcher used by tasks', () => {
+        const pkg = require('../../../package.json') as {
+            contributes: { problemMatchers: PackageProblemMatcher[] };
+        };
+        const matcher = pkg.contributes.problemMatchers.find(item => item.name === 'vscode-vivado-vivado');
+
+        assert.ok(matcher, 'package.json must contribute vscode-vivado-vivado');
+        assert.strictEqual(matcher.owner, 'vscode-vivado');
+        assert.strictEqual(matcher.fileLocation, 'absolute');
+        assert.strictEqual(matcher.pattern.length, 1);
+        assert.deepStrictEqual(matcher.pattern[0], {
+            regexp: vivadoDiagnosticLinePattern.source,
+            severity: 2,
+            code: 3,
+            message: 4,
+            file: 5,
+            line: 6,
+            column: 7,
+        });
+    });
+});

--- a/src/test/utils/vivado-run.test.ts
+++ b/src/test/utils/vivado-run.test.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { vivadoTaskSource } from '../../constants';
+import { vivadoProblemMatcher, vivadoTaskSource } from '../../constants';
 import { VivadoSettings } from '../../utils/vivado-settings';
 import {
     buildVivadoCommandLine,
@@ -240,6 +240,49 @@ suite('vivadoRun task execution', () => {
 
         assert.strictEqual(getTask()?.name, 'custom-vivado-task');
         assert.strictEqual(getTask()?.source, vivadoTaskSource);
+    });
+
+    test('uses the Vivado problem matcher by default', async () => {
+        const { cleanup, getTask } = stubVivadoRunTasks(0);
+
+        try {
+            await vivadoRun(
+                vscode.Uri.file('/workspace'),
+                'exit',
+                'problem-matcher-default',
+                {
+                    settings: makeSettings(),
+                    platform: 'win32',
+                    tclDirectory: makeTclDirectory(),
+                },
+            );
+        } finally {
+            cleanup();
+        }
+
+        assert.deepStrictEqual(getTask()?.problemMatchers, [vivadoProblemMatcher]);
+    });
+
+    test('allows callers to override Vivado problem matchers', async () => {
+        const { cleanup, getTask } = stubVivadoRunTasks(0);
+
+        try {
+            await vivadoRun(
+                vscode.Uri.file('/workspace'),
+                'exit',
+                'problem-matcher-override',
+                {
+                    settings: makeSettings(),
+                    platform: 'win32',
+                    problemMatchers: [],
+                    tclDirectory: makeTclDirectory(),
+                },
+            );
+        } finally {
+            cleanup();
+        }
+
+        assert.deepStrictEqual(getTask()?.problemMatchers, []);
     });
 
     test('resolves with the task exit code', async () => {

--- a/src/utils/vivado-diagnostics.ts
+++ b/src/utils/vivado-diagnostics.ts
@@ -1,0 +1,56 @@
+export type VivadoDiagnosticSeverity = 'error' | 'warning' | 'info';
+
+export interface VivadoDiagnosticMessage {
+    severity: VivadoDiagnosticSeverity;
+    rawSeverity: string;
+    code: string;
+    message: string;
+    filePath: string;
+    line: number;
+    column?: number;
+}
+
+export const vivadoDiagnosticLinePattern = /^(?:(CRITICAL)\s+)?(ERROR|WARNING|INFO):\s+\[([^\]]+)\]\s*(.*?)\s+\[(.+?):(\d+)(?::(\d+))?\]\s*$/;
+
+export function parseVivadoDiagnosticLine(line: string): VivadoDiagnosticMessage | undefined {
+    const match = line.match(vivadoDiagnosticLinePattern);
+    if (!match) {
+        return undefined;
+    }
+
+    const critical = match[1];
+    const severity = match[2];
+    const lineNumber = Number.parseInt(match[6], 10);
+    const column = match[7] ? Number.parseInt(match[7], 10) : undefined;
+
+    if (!Number.isInteger(lineNumber) || lineNumber < 1 || (column !== undefined && (!Number.isInteger(column) || column < 1))) {
+        return undefined;
+    }
+
+    return {
+        severity: normalizeVivadoSeverity(severity),
+        rawSeverity: critical ? `${critical} ${severity}` : severity,
+        code: match[3].trim(),
+        message: match[4].trim(),
+        filePath: match[5],
+        line: lineNumber,
+        column,
+    };
+}
+
+export function parseVivadoDiagnosticLines(lines: readonly string[]): VivadoDiagnosticMessage[] {
+    return lines
+        .map(parseVivadoDiagnosticLine)
+        .filter((message): message is VivadoDiagnosticMessage => message !== undefined);
+}
+
+function normalizeVivadoSeverity(severity: string): VivadoDiagnosticSeverity {
+    switch (severity) {
+        case 'ERROR':
+            return 'error';
+        case 'INFO':
+            return 'info';
+        default:
+            return 'warning';
+    }
+}

--- a/src/utils/vivado-run.ts
+++ b/src/utils/vivado-run.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import * as vscode from 'vscode';
-import { vivadoTaskSource } from '../constants';
+import { vivadoProblemMatcher, vivadoTaskSource } from '../constants';
 import { OutputConsole } from '../output-console';
 import { getVivadoSettings, VivadoSettings } from './vivado-settings';
 import {
@@ -166,13 +166,14 @@ function buildVivadoTask(
         },
     );
 
+    const problemMatchers = options.problemMatchers ?? [vivadoProblemMatcher];
     const task = new vscode.Task(
         { type: 'shell' },
         vscode.TaskScope.Workspace,
         taskName,
         vivadoTaskSource,
         shellExecution,
-        options.problemMatchers,
+        problemMatchers,
     );
 
     if (options.presentationOptions !== undefined) {


### PR DESCRIPTION
## Summary
- contribute a Vivado task problem matcher for file-backed ERROR, WARNING, CRITICAL WARNING, and INFO messages
- attach the matcher by default to Vivado task execution while preserving caller overrides
- add fixture-backed parser coverage for linked and non-linkable Vivado messages
- document current task-output diagnostics support

Closes #13

## Validation
- npm run compile
- npm run lint
- npm test
- make PYTHON=C:/Users/cosgroma/.pyenv/pyenv-win/versions/3.11.9/python.exe docs
- git diff --check