### PR TITLE
Surface Vivado report summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ for the current user-facing workflows.
   tasks.
 - Surface file-backed Vivado task diagnostics in Problems when Vivado emits
   file and line locations.
+- Surface timing, utilization, DRC, methodology, and power report files with
+  best-effort summaries in the project tree.
 - Preview generated TCL without executing Vivado.
 - Reset selected synthesis or implementation runs.
 - Clean generated outputs for selected synthesis or implementation runs.

--- a/docs/features.md
+++ b/docs/features.md
@@ -163,6 +163,18 @@ link back to the emitted file location.
 Messages without usable file and line data remain in the task terminal and
 generated logs so they can still be searched and copied.
 
+### Vivado Report Summaries
+
+The Reports tree links discovered `.rpt` files from the configured
+`vscode-vivado.reportsDirectory` location and from Vivado run output
+directories such as `<project>.runs/<run>`. Report nodes open the raw report
+file.
+
+Timing, utilization, DRC, methodology, and power reports show best-effort
+summaries when the extension can parse common Vivado report text. Missing
+reports or unrecognized report formats leave the report node openable without a
+summary instead of breaking the tree.
+
 ## Planned Vivado Features
 
 The extension should grow from HLS project management into Vivado project support. The desired Vivado features are listed here as the product target.
@@ -193,10 +205,11 @@ Expose common Vivado runs as VS Code commands and tasks:
 
 The extension should use Vivado TCL under the hood so every action can be reproduced outside VS Code.
 
-### Report Diagnostics
+### Generated Report Workflows
 
-Parse Vivado report files and richer run artifacts into diagnostics and
-summaries after task-output matching is complete.
+Add commands for generating timing, utilization, DRC, methodology, and power
+reports directly from VS Code, and extend parser coverage for richer report
+diagnostics.
 
 ### TCL Workflow
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,8 @@ The current Vivado workflow discovers `.xpr` projects, surfaces sources, constra
 - Run synthesis, implementation, and bitstream generation through visible TCL-backed tasks.
 - Surface file-backed Vivado task diagnostics in Problems when Vivado emits
   file and line locations.
+- Surface timing, utilization, DRC, methodology, and power report files with
+  best-effort summaries in the project tree.
 - Preview generated TCL without executing Vivado.
 - Reset selected Vivado synthesis or implementation runs.
 - Clean generated outputs for selected Vivado synthesis or implementation runs.
@@ -32,7 +34,7 @@ The current Vivado workflow discovers `.xpr` projects, surfaces sources, constra
 
 - Show RTL sources, block designs, constraints, simulation sources, IP, and generated outputs.
 - Run simulation and report-generation flows from VS Code tasks.
-- Extend Vivado report diagnostics and summaries.
+- Extend Vivado report diagnostics and generated report workflows.
 - Support TCL-first automation so the extension can mirror reproducible command-line flows.
 - Keep Vitis HLS support available where it helps FPGA projects that use both HLS and Vivado.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -82,6 +82,8 @@ Default:
 ## `vscode-vivado.reportsDirectory`
 
 Optional workspace-relative directory for generated or copied report artifacts.
+The project tree scans this directory, plus Vivado run output directories such
+as `<project>.runs/<run>`, for `.rpt` files.
 
 Default:
 

--- a/src/models/vivado-report.ts
+++ b/src/models/vivado-report.ts
@@ -5,7 +5,13 @@ export enum VivadoReportKind {
     Utilization = 'utilization',
     Power = 'power',
     Drc = 'drc',
+    Methodology = 'methodology',
     Other = 'other',
+}
+
+export interface VivadoReportSummary {
+    description: string;
+    details?: string[];
 }
 
 export interface VivadoReportOptions {
@@ -13,6 +19,7 @@ export interface VivadoReportOptions {
     uri: vscode.Uri;
     kind: VivadoReportKind;
     runName?: string;
+    summary?: VivadoReportSummary;
 }
 
 export class VivadoReport {
@@ -20,11 +27,13 @@ export class VivadoReport {
     public uri: vscode.Uri;
     public kind: VivadoReportKind;
     public runName?: string;
+    public summary?: VivadoReportSummary;
 
     constructor(options: VivadoReportOptions) {
         this.name = options.name;
         this.uri = options.uri;
         this.kind = options.kind;
         this.runName = options.runName;
+        this.summary = options.summary;
     }
 }

--- a/src/test/fixtures/reports/drc.rpt
+++ b/src/test/fixtures/reports/drc.rpt
@@ -1,0 +1,5 @@
+Report DRC
+
+ERROR: [DRC NSTD-1] Unspecified I/O Standard.
+CRITICAL WARNING: [DRC UCIO-1] Unconstrained Logical Port.
+WARNING: [DRC RTSTAT-1] Routethrough status warning.

--- a/src/test/fixtures/reports/methodology.rpt
+++ b/src/test/fixtures/reports/methodology.rpt
@@ -1,0 +1,4 @@
+Report Methodology
+
+CRITICAL WARNING: [Methodology 23-20] Clock net has no buffer.
+WARNING: [Methodology 23-1] Review generated clock constraints.

--- a/src/test/fixtures/reports/power.rpt
+++ b/src/test/fixtures/reports/power.rpt
@@ -1,0 +1,3 @@
+Power Report
+
+Total On-Chip Power (W): 2.345

--- a/src/test/fixtures/reports/timing_summary.rpt
+++ b/src/test/fixtures/reports/timing_summary.rpt
@@ -1,0 +1,7 @@
+Timing Summary
+
+| WNS(ns) | TNS(ns) | TNS Failing Endpoints |
+|---------|---------|-----------------------|
+|  -0.123 |  -1.234 |                     5 |
+
+Failing Clocks: sys_clk

--- a/src/test/fixtures/reports/utilization.rpt
+++ b/src/test/fixtures/reports/utilization.rpt
@@ -1,0 +1,8 @@
+Utilization Summary
+
+| Site Type       | Used | Fixed | Available | Util% |
+|-----------------|------|-------|-----------|-------|
+| Slice LUTs      | 1234 |     0 |     20800 |  5.93 |
+| Slice Registers | 5678 |     0 |     41600 | 13.65 |
+| Block RAM Tile  |   10 |     0 |        50 | 20.00 |
+| DSPs            |    4 |     0 |        90 |  4.44 |

--- a/src/test/models/vivado-project.test.ts
+++ b/src/test/models/vivado-project.test.ts
@@ -98,6 +98,10 @@ function makeProject(): VivadoProject {
                 uri: uri(path.join('/workspace', 'board-design', 'reports', 'timing_summary.rpt')),
                 kind: VivadoReportKind.Timing,
                 runName: 'impl_1',
+                summary: {
+                    description: 'WNS -0.123 ns',
+                    details: ['Worst negative slack: -0.123 ns'],
+                },
             }),
         ],
     });
@@ -149,6 +153,7 @@ suite('VivadoProject', () => {
         assert.strictEqual(project.blockDesigns[0].isOutOfDate, true);
         assert.strictEqual(project.reports[0].kind, VivadoReportKind.Timing);
         assert.strictEqual(project.reports[0].runName, 'impl_1');
+        assert.strictEqual(project.reports[0].summary?.description, 'WNS -0.123 ns');
     });
 
     test('filters runs by Vivado run type', () => {

--- a/src/test/utils/vivado-reports.test.ts
+++ b/src/test/utils/vivado-reports.test.ts
@@ -1,0 +1,187 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { VivadoProject } from '../../models/vivado-project';
+import { VivadoReportKind } from '../../models/vivado-report';
+import { VivadoRun, VivadoRunType } from '../../models/vivado-run';
+import {
+    classifyVivadoReport,
+    discoverVivadoReports,
+    parseVivadoReportSummary,
+} from '../../utils/vivado-reports';
+import { loadVivadoProjectFromXpr } from '../../utils/vivado-xpr';
+
+function readReportFixture(name: string): string {
+    const fixturePath = path.resolve(__dirname, '../../../src/test/fixtures/reports', name);
+    return fs.readFileSync(fixturePath, 'utf8');
+}
+
+function writeReportFixture(destination: string, fixtureName: string): void {
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.copyFileSync(path.resolve(__dirname, '../../../src/test/fixtures/reports', fixtureName), destination);
+}
+
+function makeProject(root: string): VivadoProject {
+    return new VivadoProject({
+        name: 'board',
+        uri: vscode.Uri.file(root),
+        xprFile: vscode.Uri.file(path.join(root, 'board.xpr')),
+        runs: [
+            new VivadoRun({
+                name: 'synth_1',
+                type: VivadoRunType.Synthesis,
+            }),
+            new VivadoRun({
+                name: 'impl_1',
+                type: VivadoRunType.Implementation,
+            }),
+        ],
+    });
+}
+
+suite('Vivado report summaries', () => {
+    test('classifies common Vivado report names', () => {
+        assert.strictEqual(classifyVivadoReport('top_timing_summary_routed.rpt'), VivadoReportKind.Timing);
+        assert.strictEqual(classifyVivadoReport('top_utilization_placed.rpt'), VivadoReportKind.Utilization);
+        assert.strictEqual(classifyVivadoReport('top_methodology_drc_routed.rpt'), VivadoReportKind.Methodology);
+        assert.strictEqual(classifyVivadoReport('top_drc_routed.rpt'), VivadoReportKind.Drc);
+        assert.strictEqual(classifyVivadoReport('top_power_routed.rpt'), VivadoReportKind.Power);
+        assert.strictEqual(classifyVivadoReport('unknown_report.rpt'), VivadoReportKind.Other);
+    });
+
+    test('parses timing summary metrics from fixture output', () => {
+        const summary = parseVivadoReportSummary(VivadoReportKind.Timing, readReportFixture('timing_summary.rpt'));
+
+        assert.strictEqual(summary?.description, 'WNS -0.123 ns, TNS -1.234 ns, 5 failing endpoints');
+        assert.deepStrictEqual(summary?.details, [
+            'Worst negative slack: -0.123 ns',
+            'Total negative slack: -1.234 ns',
+            'Failing endpoints: 5',
+            'Failing clocks: sys_clk',
+        ]);
+    });
+
+    test('parses utilization summary metrics from fixture output', () => {
+        const summary = parseVivadoReportSummary(VivadoReportKind.Utilization, readReportFixture('utilization.rpt'));
+
+        assert.strictEqual(
+            summary?.description,
+            'LUT 1234/20800 (5.93%), FF 5678/41600 (13.65%), BRAM 10/50 (20.00%), DSP 4/90 (4.44%)',
+        );
+    });
+
+    test('parses DRC and methodology severity summaries from fixture output', () => {
+        const drcSummary = parseVivadoReportSummary(VivadoReportKind.Drc, readReportFixture('drc.rpt'));
+        const methodologySummary = parseVivadoReportSummary(VivadoReportKind.Methodology, readReportFixture('methodology.rpt'));
+
+        assert.strictEqual(drcSummary?.description, 'DRC: 1 error, 1 critical warning, 1 warning');
+        assert.deepStrictEqual(drcSummary?.details, [
+            'Errors: 1',
+            'Critical warnings: 1',
+            'Warnings: 1',
+        ]);
+        assert.strictEqual(methodologySummary?.description, 'Methodology: 1 critical warning, 1 warning');
+    });
+
+    test('parses report severity count labels without mixing warning classes', () => {
+        const summary = parseVivadoReportSummary(
+            VivadoReportKind.Drc,
+            [
+                'Errors: 0',
+                'Critical Warnings: 2',
+                'Warnings: 3',
+            ].join('\n'),
+        );
+
+        assert.strictEqual(summary?.description, 'DRC: 2 critical warnings, 3 warnings');
+        assert.deepStrictEqual(summary?.details, [
+            'Errors: 0',
+            'Critical warnings: 2',
+            'Warnings: 3',
+        ]);
+    });
+
+    test('parses power summary metrics from fixture output', () => {
+        const summary = parseVivadoReportSummary(VivadoReportKind.Power, readReportFixture('power.rpt'));
+
+        assert.strictEqual(summary?.description, 'Power 2.345 W');
+        assert.deepStrictEqual(summary?.details, ['Total on-chip power: 2.345 W']);
+    });
+
+    test('returns no summary for unrecognized report content', () => {
+        assert.strictEqual(parseVivadoReportSummary(VivadoReportKind.Other, 'plain text'), undefined);
+        assert.strictEqual(parseVivadoReportSummary(VivadoReportKind.Timing, 'no timing numbers here'), undefined);
+    });
+});
+
+suite('Vivado report discovery', () => {
+    const tempRoots: string[] = [];
+
+    teardown(() => {
+        while (tempRoots.length > 0) {
+            const root = tempRoots.pop();
+            if (root) {
+                fs.rmSync(root, { recursive: true, force: true });
+            }
+        }
+    });
+
+    test('discovers configured and run-output reports with summaries', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-vivado-reports-'));
+        tempRoots.push(root);
+        writeReportFixture(path.join(root, 'reports', 'timing_summary.rpt'), 'timing_summary.rpt');
+        writeReportFixture(path.join(root, 'board.runs', 'impl_1', 'top_utilization_placed.rpt'), 'utilization.rpt');
+        fs.writeFileSync(path.join(root, 'reports', 'notes.txt'), 'not a report');
+
+        const reports = await discoverVivadoReports(makeProject(root), {
+            reportsDirectory: 'reports',
+        });
+
+        assert.deepStrictEqual(reports.map(report => report.name), [
+            'top_utilization_placed.rpt',
+            'timing_summary.rpt',
+        ]);
+        assert.strictEqual(reports[0].kind, VivadoReportKind.Utilization);
+        assert.strictEqual(reports[0].runName, 'impl_1');
+        assert.ok(reports[0].summary?.description.includes('LUT 1234/20800'));
+        assert.strictEqual(reports[1].kind, VivadoReportKind.Timing);
+        assert.strictEqual(reports[1].runName, undefined);
+        assert.strictEqual(reports[1].summary?.description, 'WNS -0.123 ns, TNS -1.234 ns, 5 failing endpoints');
+    });
+
+    test('degrades to no reports when report directories are missing', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-vivado-no-reports-'));
+        tempRoots.push(root);
+
+        const reports = await discoverVivadoReports(makeProject(root), {
+            reportsDirectory: 'reports',
+        });
+
+        assert.deepStrictEqual(reports, []);
+    });
+
+    test('loadVivadoProjectFromXpr attaches discovered report summaries', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-vivado-xpr-reports-'));
+        tempRoots.push(root);
+        fs.writeFileSync(path.join(root, 'board.xpr'), `<Project>
+          <Configuration>
+            <Option Name="ProjectName" Val="board" />
+          </Configuration>
+          <Runs>
+            <Run Id="impl_1" Type="Ft2:EntireDesign" />
+          </Runs>
+        </Project>`);
+        writeReportFixture(path.join(root, 'board.runs', 'impl_1', 'top_drc_routed.rpt'), 'drc.rpt');
+
+        const project = await loadVivadoProjectFromXpr(vscode.Uri.file(path.join(root, 'board.xpr')), {
+            reportsDirectory: 'reports',
+        });
+
+        assert.strictEqual(project.reports.length, 1);
+        assert.strictEqual(project.reports[0].kind, VivadoReportKind.Drc);
+        assert.strictEqual(project.reports[0].runName, 'impl_1');
+        assert.strictEqual(project.reports[0].summary?.description, 'DRC: 1 error, 1 critical warning, 1 warning');
+    });
+});

--- a/src/test/views/projects-tree.test.ts
+++ b/src/test/views/projects-tree.test.ts
@@ -373,6 +373,24 @@ suite('ProjectsViewTreeProvider', () => {
         assert.strictEqual(reports[0].command?.command, 'vscode.open');
     });
 
+    test('Vivado report nodes display available summaries', () => {
+        const report = new VivadoReport({
+            name: 'timing_summary.rpt',
+            uri: vscode.Uri.file('/workspace/board/reports/timing_summary.rpt'),
+            kind: VivadoReportKind.Timing,
+            runName: 'impl_1',
+            summary: {
+                description: 'WNS -0.123 ns, TNS -1.234 ns',
+                details: ['Worst negative slack: -0.123 ns'],
+            },
+        });
+        const item = new VivadoReportTreeItem(report);
+
+        assert.strictEqual(item.description, 'WNS -0.123 ns, TNS -1.234 ns');
+        assert.ok(String(item.tooltip).includes('Run: impl_1'));
+        assert.ok(String(item.tooltip).includes('Worst negative slack: -0.123 ns'));
+    });
+
     test('Vivado project and category nodes stay stable across refreshes', async () => {
         vivadoProjectsProvider.projects = [makeVivadoProject('board', {
             designSources: ['rtl/old_top.sv'],

--- a/src/test/vivado-project-manager.test.ts
+++ b/src/test/vivado-project-manager.test.ts
@@ -146,6 +146,26 @@ suite('VivadoProjectManager', () => {
         assert.strictEqual(projects[0].name, 'no-vivado');
     });
 
+    test('passes configured report directory settings to the project loader', async () => {
+        const xprFile = vscode.Uri.file(path.join('/workspace', 'reports-demo', 'reports-demo.xpr'));
+        let receivedSettings: VivadoSettings | undefined;
+        const { manager } = makeManager({
+            getSettings: () => makeSettings({
+                reportsDirectory: 'vivado-reports',
+            }),
+            findFiles: () => Promise.resolve([xprFile]),
+            loadProject: async (file, settings) => {
+                receivedSettings = settings;
+                return makeProject(file);
+            },
+        });
+
+        manager.refresh();
+        await manager.getProjects();
+
+        assert.strictEqual(receivedSettings?.reportsDirectory, 'vivado-reports');
+    });
+
     test('replaces stale project entries on refresh', async () => {
         const firstProject = vscode.Uri.file(path.join('/workspace', 'first', 'first.xpr'));
         const secondProject = vscode.Uri.file(path.join('/workspace', 'second', 'second.xpr'));

--- a/src/utils/vivado-reports.ts
+++ b/src/utils/vivado-reports.ts
@@ -1,0 +1,464 @@
+import path from 'path';
+import * as vscode from 'vscode';
+import { VivadoProject } from '../models/vivado-project';
+import { VivadoReport, VivadoReportKind, VivadoReportSummary } from '../models/vivado-report';
+
+interface ReportFileSystem {
+    readDirectory(uri: vscode.Uri): Thenable<[string, vscode.FileType][]>;
+    readFile(uri: vscode.Uri): Thenable<Uint8Array>;
+}
+
+export interface DiscoverVivadoReportsOptions {
+    reportsDirectory: string;
+    fs: ReportFileSystem;
+    maxDepth: number;
+    maxFiles: number;
+}
+
+interface UtilizationRow {
+    name: string;
+    label: string;
+    used: string;
+    available?: string;
+    percent?: string;
+}
+
+interface SeverityCounts {
+    errors: number;
+    criticalWarnings: number;
+    warnings: number;
+}
+
+const defaultReportsDirectory = 'reports';
+const defaultMaxDepth = 6;
+const defaultMaxFiles = 250;
+
+export async function discoverVivadoReports(
+    project: VivadoProject,
+    options: Partial<DiscoverVivadoReportsOptions> = {},
+): Promise<VivadoReport[]> {
+    const fs = options.fs ?? vscode.workspace.fs;
+    const reportsDirectory = options.reportsDirectory ?? defaultReportsDirectory;
+    const maxDepth = options.maxDepth ?? defaultMaxDepth;
+    const maxFiles = options.maxFiles ?? defaultMaxFiles;
+    const reportUris = await collectReportUris(candidateReportDirectories(project, reportsDirectory), fs, maxDepth, maxFiles);
+    const runNames = project.runs.map(run => run.name);
+
+    const reports = await Promise.all(reportUris.map(async uri => {
+        const name = path.basename(uri.fsPath);
+        const kind = classifyVivadoReport(name);
+        const summary = await readVivadoReportSummary(uri, kind, fs);
+
+        return new VivadoReport({
+            name,
+            uri,
+            kind,
+            runName: inferRunName(uri, runNames),
+            summary,
+        });
+    }));
+
+    return reports.sort((a, b) => a.uri.fsPath.localeCompare(b.uri.fsPath));
+}
+
+export function classifyVivadoReport(fileName: string): VivadoReportKind {
+    const normalizedName = fileName.toLowerCase();
+
+    if (normalizedName.includes('timing')) {
+        return VivadoReportKind.Timing;
+    }
+
+    if (normalizedName.includes('util')) {
+        return VivadoReportKind.Utilization;
+    }
+
+    if (normalizedName.includes('methodology')) {
+        return VivadoReportKind.Methodology;
+    }
+
+    if (normalizedName.includes('drc')) {
+        return VivadoReportKind.Drc;
+    }
+
+    if (normalizedName.includes('power')) {
+        return VivadoReportKind.Power;
+    }
+
+    return VivadoReportKind.Other;
+}
+
+export function parseVivadoReportSummary(kind: VivadoReportKind, content: string): VivadoReportSummary | undefined {
+    switch (kind) {
+        case VivadoReportKind.Timing:
+            return parseTimingSummary(content);
+        case VivadoReportKind.Utilization:
+            return parseUtilizationSummary(content);
+        case VivadoReportKind.Drc:
+            return parseSeveritySummary('DRC', parseSeverityCounts(content, 'DRC'));
+        case VivadoReportKind.Methodology:
+            return parseSeveritySummary('Methodology', parseSeverityCounts(content, 'Methodology'));
+        case VivadoReportKind.Power:
+            return parsePowerSummary(content);
+        default:
+            return undefined;
+    }
+}
+
+async function readVivadoReportSummary(
+    uri: vscode.Uri,
+    kind: VivadoReportKind,
+    fs: ReportFileSystem,
+): Promise<VivadoReportSummary | undefined> {
+    try {
+        const data = await fs.readFile(uri);
+        return parseVivadoReportSummary(kind, Buffer.from(data).toString('utf8'));
+    } catch {
+        return undefined;
+    }
+}
+
+function candidateReportDirectories(project: VivadoProject, reportsDirectory: string): vscode.Uri[] {
+    const directories = [
+        resolveConfiguredReportsDirectory(project, reportsDirectory),
+        vscode.Uri.joinPath(project.uri, `${project.name}.runs`),
+    ];
+    const seen = new Set<string>();
+
+    return directories.filter(uri => {
+        const key = uri.toString();
+        if (seen.has(key)) {
+            return false;
+        }
+
+        seen.add(key);
+        return true;
+    });
+}
+
+function resolveConfiguredReportsDirectory(project: VivadoProject, reportsDirectory: string): vscode.Uri {
+    const normalizedDirectory = reportsDirectory.trim() || defaultReportsDirectory;
+
+    if (path.isAbsolute(normalizedDirectory)) {
+        return vscode.Uri.file(path.normalize(normalizedDirectory));
+    }
+
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(project.uri);
+    return joinUriPath(workspaceFolder?.uri ?? project.uri, normalizedDirectory);
+}
+
+function joinUriPath(base: vscode.Uri, relativePath: string): vscode.Uri {
+    const segments = relativePath.split(/[\\/]+/).filter(segment => segment.length > 0);
+    return segments.length === 0 ? base : vscode.Uri.joinPath(base, ...segments);
+}
+
+async function collectReportUris(
+    directories: vscode.Uri[],
+    fs: ReportFileSystem,
+    maxDepth: number,
+    maxFiles: number,
+): Promise<vscode.Uri[]> {
+    const reports: vscode.Uri[] = [];
+    const seen = new Set<string>();
+
+    for (const directory of directories) {
+        await collectReportUrisFromDirectory(directory, fs, maxDepth, maxFiles, reports, seen);
+    }
+
+    return reports;
+}
+
+async function collectReportUrisFromDirectory(
+    directory: vscode.Uri,
+    fs: ReportFileSystem,
+    depthRemaining: number,
+    maxFiles: number,
+    reports: vscode.Uri[],
+    seen: Set<string>,
+): Promise<void> {
+    if (depthRemaining < 0 || reports.length >= maxFiles) {
+        return;
+    }
+
+    let entries: [string, vscode.FileType][];
+    try {
+        entries = await fs.readDirectory(directory);
+    } catch {
+        return;
+    }
+
+    entries.sort(([left], [right]) => left.localeCompare(right));
+    for (const [name, type] of entries) {
+        if (reports.length >= maxFiles) {
+            return;
+        }
+
+        const uri = vscode.Uri.joinPath(directory, name);
+        if ((type & vscode.FileType.Directory) !== 0) {
+            await collectReportUrisFromDirectory(uri, fs, depthRemaining - 1, maxFiles, reports, seen);
+            continue;
+        }
+
+        if (!isReportFileName(name)) {
+            continue;
+        }
+
+        const key = uri.toString();
+        if (!seen.has(key)) {
+            seen.add(key);
+            reports.push(uri);
+        }
+    }
+}
+
+function isReportFileName(fileName: string): boolean {
+    return path.extname(fileName).toLowerCase() === '.rpt';
+}
+
+function inferRunName(uri: vscode.Uri, runNames: string[]): string | undefined {
+    const normalizedPath = uri.fsPath.replace(/\\/g, '/').toLowerCase();
+    const segments = normalizedPath.split('/');
+
+    return runNames.find(runName => {
+        const normalizedRunName = runName.toLowerCase();
+        return segments.includes(normalizedRunName) || path.basename(normalizedPath).includes(normalizedRunName);
+    });
+}
+
+function parseTimingSummary(content: string): VivadoReportSummary | undefined {
+    const tableValues = readValuesFromTable(content, ['WNS(ns)', 'TNS(ns)', 'TNS Failing Endpoints']);
+    const wns = findMetric(content, ['WNS(ns)', 'WNS']) ?? tableValues.get(normalizeHeader('WNS(ns)'));
+    const tns = findMetric(content, ['TNS(ns)', 'TNS']) ?? tableValues.get(normalizeHeader('TNS(ns)'));
+    const failingEndpoints = findMetric(content, ['TNS Failing Endpoints', 'Failing Endpoints'])
+        ?? tableValues.get(normalizeHeader('TNS Failing Endpoints'));
+    const failingClock = findTextMetric(content, ['Failing Clock', 'Failing Clocks']);
+    const parts = [
+        wns ? `WNS ${formatNanoseconds(wns)}` : undefined,
+        tns ? `TNS ${formatNanoseconds(tns)}` : undefined,
+        failingEndpoints ? `${failingEndpoints} failing endpoints` : undefined,
+    ].filter((part): part is string => part !== undefined);
+
+    if (parts.length === 0 && !failingClock) {
+        return undefined;
+    }
+
+    return {
+        description: parts.join(', ') || `Failing clocks: ${failingClock}`,
+        details: [
+            wns ? `Worst negative slack: ${formatNanoseconds(wns)}` : undefined,
+            tns ? `Total negative slack: ${formatNanoseconds(tns)}` : undefined,
+            failingEndpoints ? `Failing endpoints: ${failingEndpoints}` : undefined,
+            failingClock ? `Failing clocks: ${failingClock}` : undefined,
+        ].filter((line): line is string => line !== undefined),
+    };
+}
+
+function parseUtilizationSummary(content: string): VivadoReportSummary | undefined {
+    const rows = [
+        findUtilizationRow(content, 'LUT', ['Slice LUTs', 'CLB LUTs']),
+        findUtilizationRow(content, 'FF', ['Slice Registers', 'CLB Registers', 'Register as Flip Flop']),
+        findUtilizationRow(content, 'BRAM', ['Block RAM Tile', 'RAMB36/FIFO', 'Block RAM']),
+        findUtilizationRow(content, 'DSP', ['DSPs', 'DSP48E1', 'DSP48E2']),
+    ].filter((row): row is UtilizationRow => row !== undefined);
+
+    if (rows.length === 0) {
+        return undefined;
+    }
+
+    return {
+        description: rows.map(formatUtilizationRow).join(', '),
+        details: rows.map(row => `${row.name}: ${formatUtilizationRow(row)}`),
+    };
+}
+
+function parseSeveritySummary(reportName: string, counts: SeverityCounts | undefined): VivadoReportSummary | undefined {
+    if (!counts) {
+        return undefined;
+    }
+
+    const parts = [
+        counts.errors > 0 ? pluralize(counts.errors, 'error') : undefined,
+        counts.criticalWarnings > 0 ? pluralize(counts.criticalWarnings, 'critical warning') : undefined,
+        counts.warnings > 0 ? pluralize(counts.warnings, 'warning') : undefined,
+    ].filter((part): part is string => part !== undefined);
+
+    const description = parts.length > 0 ? `${reportName}: ${parts.join(', ')}` : `${reportName}: no violations`;
+
+    return {
+        description,
+        details: [
+            `Errors: ${counts.errors}`,
+            `Critical warnings: ${counts.criticalWarnings}`,
+            `Warnings: ${counts.warnings}`,
+        ],
+    };
+}
+
+function parsePowerSummary(content: string): VivadoReportSummary | undefined {
+    const totalPower = findMetric(content, ['Total On-Chip Power (W)', 'Total On-Chip Power']);
+
+    if (!totalPower) {
+        return undefined;
+    }
+
+    return {
+        description: `Power ${totalPower} W`,
+        details: [`Total on-chip power: ${totalPower} W`],
+    };
+}
+
+function findMetric(content: string, labels: readonly string[]): string | undefined {
+    for (const label of labels) {
+        const match = content.match(new RegExp(`${metricPrefixPattern()}${labelPattern(label)}\\s*(?:[:=|])?\\s*(-?\\d+(?:\\.\\d+)?)`, 'i'));
+        if (match) {
+            return match[1];
+        }
+    }
+
+    return undefined;
+}
+
+function findTextMetric(content: string, labels: readonly string[]): string | undefined {
+    for (const label of labels) {
+        const match = content.match(new RegExp(`${metricPrefixPattern()}${labelPattern(label)}\\s*(?:[:=|])\\s*([^\\r\\n|]+)`, 'i'));
+        if (match) {
+            return match[1].trim();
+        }
+    }
+
+    return undefined;
+}
+
+function readValuesFromTable(content: string, requestedHeaders: readonly string[]): Map<string, string> {
+    const requested = new Set(requestedHeaders.map(normalizeHeader));
+    const rows = parsePipeRows(content);
+
+    for (let index = 0; index < rows.length; index++) {
+        const headers = rows[index].map(normalizeHeader);
+        if (!headers.some(header => requested.has(header))) {
+            continue;
+        }
+
+        const values = rows[index + 1];
+        if (!values) {
+            return new Map();
+        }
+
+        const result = new Map<string, string>();
+        headers.forEach((header, headerIndex) => {
+            if (requested.has(header) && values[headerIndex]) {
+                result.set(header, values[headerIndex]);
+            }
+        });
+        return result;
+    }
+
+    return new Map();
+}
+
+function findUtilizationRow(content: string, name: string, labels: readonly string[]): UtilizationRow | undefined {
+    const normalizedLabels = labels.map(label => label.toLowerCase());
+
+    for (const row of parsePipeRows(content)) {
+        const firstCell = row[0]?.toLowerCase();
+        if (!firstCell || !normalizedLabels.some(label => firstCell.includes(label))) {
+            continue;
+        }
+
+        return {
+            name,
+            label: row[0],
+            used: row[1],
+            available: row[3],
+            percent: row[4],
+        };
+    }
+
+    return undefined;
+}
+
+function parsePipeRows(content: string): string[][] {
+    return content
+        .split(/\r?\n/)
+        .filter(line => line.includes('|') && !/^[\s+|\-]+$/.test(line))
+        .map(line => line
+            .split('|')
+            .map(cell => cell.trim())
+            .filter(cell => cell.length > 0))
+        .filter(row => row.length > 0);
+}
+
+function parseSeverityCounts(content: string, reportName: string): SeverityCounts | undefined {
+    const escapedReportName = escapeRegExp(reportName);
+    const messagePattern = new RegExp(`^(CRITICAL WARNING|ERROR|WARNING):\\s+\\[${escapedReportName}[^\\]]*\\]`, 'im');
+    const counts = content.split(/\r?\n/).reduce<SeverityCounts>((summary, line) => {
+        const match = line.match(messagePattern);
+        if (!match) {
+            return summary;
+        }
+
+        switch (match[1].toUpperCase()) {
+            case 'ERROR':
+                summary.errors += 1;
+                break;
+            case 'CRITICAL WARNING':
+                summary.criticalWarnings += 1;
+                break;
+            default:
+                summary.warnings += 1;
+                break;
+        }
+
+        return summary;
+    }, { errors: 0, criticalWarnings: 0, warnings: 0 });
+
+    const labelCounts = {
+        errors: findCountMetric(content, ['Errors', 'Error']),
+        criticalWarnings: findCountMetric(content, ['Critical Warnings', 'Critical Warning']),
+        warnings: findCountMetric(content, ['Warnings', 'Warning']),
+    };
+    const foundLabelCount = Object.values(labelCounts).some(value => value !== undefined);
+
+    if (foundLabelCount) {
+        return {
+            errors: labelCounts.errors ?? counts.errors,
+            criticalWarnings: labelCounts.criticalWarnings ?? counts.criticalWarnings,
+            warnings: labelCounts.warnings ?? counts.warnings,
+        };
+    }
+
+    return counts.errors + counts.criticalWarnings + counts.warnings > 0 ? counts : undefined;
+}
+
+function findCountMetric(content: string, labels: readonly string[]): number | undefined {
+    const value = findMetric(content, labels);
+    return value === undefined ? undefined : Number.parseInt(value, 10);
+}
+
+function formatNanoseconds(value: string): string {
+    return `${value} ns`;
+}
+
+function formatUtilizationRow(row: UtilizationRow): string {
+    const usage = row.available ? `${row.used}/${row.available}` : row.used;
+    return row.percent ? `${row.name} ${usage} (${row.percent}%)` : `${row.name} ${usage}`;
+}
+
+function normalizeHeader(value: string): string {
+    return value.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function pluralize(count: number, singular: string): string {
+    return `${count} ${singular}${count === 1 ? '' : 's'}`;
+}
+
+function metricPrefixPattern(): string {
+    return '(?:^|[\\r\\n|])\\s*';
+}
+
+function labelPattern(label: string): string {
+    return label.split(/\s+/).map(escapeRegExp).join('\\s+');
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/utils/vivado-xpr.ts
+++ b/src/utils/vivado-xpr.ts
@@ -7,15 +7,28 @@ import { VivadoFileset, VivadoFilesetKind } from '../models/vivado-fileset';
 import { VivadoIp } from '../models/vivado-ip';
 import { VivadoProject } from '../models/vivado-project';
 import { VivadoRun, VivadoRunStatus, VivadoRunType } from '../models/vivado-run';
+import { discoverVivadoReports } from './vivado-reports';
 
 interface XmlNode {
     $?: Record<string, string | undefined>;
     [key: string]: unknown;
 }
 
-export async function loadVivadoProjectFromXpr(xprFile: vscode.Uri): Promise<VivadoProject> {
+export interface LoadVivadoProjectOptions {
+    reportsDirectory?: string;
+}
+
+export async function loadVivadoProjectFromXpr(
+    xprFile: vscode.Uri,
+    options: LoadVivadoProjectOptions = {},
+): Promise<VivadoProject> {
     const data = await vscode.workspace.fs.readFile(xprFile);
-    return parseVivadoProjectXml(Buffer.from(data).toString(), xprFile);
+    const project = await parseVivadoProjectXml(Buffer.from(data).toString(), xprFile);
+    project.reports = await discoverVivadoReports(project, {
+        reportsDirectory: options.reportsDirectory,
+    });
+
+    return project;
 }
 
 export async function parseVivadoProjectXml(xml: string, xprFile: vscode.Uri): Promise<VivadoProject> {

--- a/src/views/projects-tree.ts
+++ b/src/views/projects-tree.ts
@@ -259,7 +259,8 @@ export class VivadoReportTreeItem extends TreeItem {
         super(report.name);
         this.report = report;
         this.contextValue = 'vivadoReportItem';
-        this.description = report.runName ?? report.kind;
+        this.description = report.summary?.description ?? report.runName ?? report.kind;
+        this.tooltip = buildReportTooltip(report);
         this.resourceUri = report.uri;
         this.iconPath = new vscode.ThemeIcon('graph');
         this.command = {
@@ -268,6 +269,17 @@ export class VivadoReportTreeItem extends TreeItem {
             arguments: [report.uri],
         };
     }
+}
+
+function buildReportTooltip(report: VivadoReport): string {
+    return [
+        `Report: ${report.name}`,
+        `Kind: ${report.kind}`,
+        report.runName ? `Run: ${report.runName}` : undefined,
+        report.summary?.description ? `Summary: ${report.summary.description}` : undefined,
+        ...(report.summary?.details ?? []),
+        report.uri.fsPath,
+    ].filter((line): line is string => line !== undefined).join('\n');
 }
 
 export class ProjectFileItem extends TreeItem {

--- a/src/vivado-project-manager.ts
+++ b/src/vivado-project-manager.ts
@@ -10,7 +10,7 @@ type VivadoProjectManagerEvents = { 'projectsChanged': [] };
 export interface VivadoProjectManagerDependencies {
     findFiles: (include: vscode.GlobPattern, exclude?: vscode.GlobPattern, maxResults?: number) => Thenable<vscode.Uri[]>;
     getSettings: () => VivadoSettings;
-    loadProject: (xprFile: vscode.Uri) => Promise<VivadoProject>;
+    loadProject: (xprFile: vscode.Uri, settings: VivadoSettings) => Promise<VivadoProject>;
     appendLine: (message: string) => void;
 }
 
@@ -29,7 +29,9 @@ export default class VivadoProjectManager extends EventEmitter<VivadoProjectMana
         this.dependencies = {
             findFiles: vscode.workspace.findFiles.bind(vscode.workspace),
             getSettings: getVivadoSettings,
-            loadProject: loadVivadoProjectFromXpr,
+            loadProject: (xprFile, settings) => loadVivadoProjectFromXpr(xprFile, {
+                reportsDirectory: settings.reportsDirectory,
+            }),
             appendLine: message => OutputConsole.instance.appendLine(message),
             ...dependencies,
         };
@@ -100,7 +102,7 @@ export default class VivadoProjectManager extends EventEmitter<VivadoProjectMana
 
         await Promise.all(projectFiles.map(async file => {
             try {
-                projects.push(await this.dependencies.loadProject(file));
+                projects.push(await this.dependencies.loadProject(file, settings));
             } catch (error) {
                 const message = error instanceof Error ? error.message : String(error);
                 this.dependencies.appendLine('Error loading Vivado project: ' + message);


### PR DESCRIPTION
## Summary
- discover `.rpt` files from the configured reports directory and Vivado `<project>.runs` output directories
- classify timing, utilization, DRC, methodology, and power reports and parse best-effort summaries
- show available report summaries in the Projects tree while preserving openable raw report nodes
- add fixture-backed parser and discovery coverage

Closes #14

## Validation
- npm run compile
- npm run lint
- npm test
- make PYTHON=C:/Users/cosgroma/.pyenv/pyenv-win/versions/3.11.9/python.exe docs
- git diff --check