### PR TITLE
Add Vivado behavioral simulation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ for the current user-facing workflows.
 - Open a project in the Vivado IDE.
 - Run synthesis, implementation, and bitstream generation as TCL-backed VS Code
   tasks.
+- Run behavioral simulation for a Vivado project or selected simulation source
+  fileset through project-mode XSim.
 - Surface file-backed Vivado task diagnostics in Problems when Vivado emits
   file and line locations.
 - Surface timing, utilization, DRC, methodology, and power report files with
@@ -56,8 +58,8 @@ path. The intended direction is:
   constraints, runs, reports, IP, block designs, TCL scripts, and hardware.
 - Run Vivado tasks through visible, reproducible TCL.
 - Extend Vivado diagnostics and report summaries inside VS Code.
-- Add XSim, IP, block design, and hardware manager workflows after the project
-  foundation is reliable.
+- Extend XSim, IP, block design, and hardware manager workflows after the
+  project foundation is reliable.
 
 ## Requirements
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -119,6 +119,19 @@ project-mode implementation run. The command generates visible TCL that opens
 the `.xpr`, calls `launch_runs -to_step write_bitstream`, waits for the run,
 and checks that Vivado reports `PROGRESS` as `100%`.
 
+### Run Behavioral Simulation
+
+Use the `Run Behavioral Simulation` context action on a Vivado project node or
+simulation source file to launch project-mode XSim as a VS Code task. Project
+targets use the `sim_1` simulation fileset when it exists, then fall back to the
+first simulation fileset. Simulation source file targets use the file's
+associated simulation fileset.
+
+The command generates visible TCL that opens the `.xpr`, selects the simulation
+fileset, calls `launch_simulation -mode behavioral`, and runs the simulation
+with `run all`. Simulation output stays in the task terminal, and the task can
+be canceled through VS Code's normal task controls.
+
 ### Preview Generated TCL
 
 Use the `Preview Generated TCL` context action on a Vivado project node,
@@ -200,7 +213,7 @@ about the project:
 Expose common Vivado runs as VS Code commands and tasks:
 
 - Elaborate design.
-- Run behavioral simulation.
+- Add post-synthesis and post-implementation simulation.
 - Open timing, utilization, DRC, and power reports.
 
 The extension should use Vivado TCL under the hood so every action can be reproduced outside VS Code.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,11 +48,12 @@ Use the run context actions to:
 - run synthesis,
 - run implementation,
 - generate bitstreams,
+- run behavioral simulation,
 - reset selected synthesis or implementation runs,
 - clean generated outputs for selected synthesis or implementation runs.
 
-Simulation, IP, block design, and hardware-manager commands are still under
-development.
+Post-synthesis simulation, IP, block design, and hardware-manager commands are
+still under development.
 
 ## Configure Tool Paths Today
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,8 @@ The current Vivado workflow discovers `.xpr` projects, surfaces sources, constra
 - Browse Vivado design sources, simulation sources, constraints, runs, and reports.
 - Open Vivado projects in the Vivado IDE.
 - Run synthesis, implementation, and bitstream generation through visible TCL-backed tasks.
+- Run behavioral simulation through project-mode XSim from a Vivado project or
+  selected simulation source.
 - Surface file-backed Vivado task diagnostics in Problems when Vivado emits
   file and line locations.
 - Surface timing, utilization, DRC, methodology, and power report files with
@@ -33,7 +35,7 @@ The current Vivado workflow discovers `.xpr` projects, surfaces sources, constra
 ## Desired Vivado Support
 
 - Show RTL sources, block designs, constraints, simulation sources, IP, and generated outputs.
-- Run simulation and report-generation flows from VS Code tasks.
+- Extend simulation and report-generation flows from VS Code tasks.
 - Extend Vivado report diagnostics and generated report workflows.
 - Support TCL-first automation so the extension can mirror reproducible command-line flows.
 - Keep Vitis HLS support available where it helps FPGA projects that use both HLS and Vivado.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -92,7 +92,7 @@ Vivado output should become actionable inside VS Code:
 
 Vivado Simulator support should be a first-class workflow:
 
-- Run behavioral simulation for a selected simulation fileset or testbench.
+- Extend behavioral simulation beyond project-mode fileset launches.
 - Support `xvhdl`, `xvlog`, `xelab`, and `xsim` where standalone simulator commands are useful.
 - Launch waveform viewing in Vivado.
 - Save and reopen waveform configurations.

--- a/package.json
+++ b/package.json
@@ -159,6 +159,11 @@
         "command": "vscode-vivado.projects.generateBitstream",
         "title": "Generate Bitstream",
         "icon": "$(circuit-board)"
+      },
+      {
+        "command": "vscode-vivado.projects.runBehavioralSimulation",
+        "title": "Run Behavioral Simulation",
+        "icon": "$(debug-start)"
       }
     ],
     "viewsContainers": {
@@ -227,6 +232,10 @@
         {
           "command": "vscode-vivado.projects.generateBitstream",
           "when": "false"
+        },
+        {
+          "command": "vscode-vivado.projects.runBehavioralSimulation",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -265,7 +274,7 @@
         {
           "command": "vscode-vivado.projects.previewGeneratedTcl",
           "when": "view == projectsView && viewItem == vivadoProjectItem",
-          "group": "inline@4"
+          "group": "inline@5"
         },
         {
           "command": "vscode-vivado.projects.runSynthesis",
@@ -306,6 +315,16 @@
           "command": "vscode-vivado.projects.generateBitstream",
           "when": "view == projectsView && viewItem == vivadoProjectItem",
           "group": "inline@3"
+        },
+        {
+          "command": "vscode-vivado.projects.runBehavioralSimulation",
+          "when": "view == projectsView && viewItem == vivadoProjectItem",
+          "group": "inline@4"
+        },
+        {
+          "command": "vscode-vivado.projects.runBehavioralSimulation",
+          "when": "view == projectsView && viewItem == vivadoSimulationSourceFileItem",
+          "group": "inline"
         },
         {
           "command": "vscode-vivado.projects.generateBitstream",

--- a/src/commands/vivado/run-behavioral-simulation.ts
+++ b/src/commands/vivado/run-behavioral-simulation.ts
@@ -1,0 +1,182 @@
+import path from 'path';
+import * as vscode from 'vscode';
+import { vivadoTaskSource } from '../../constants';
+import { VivadoFile, VivadoFileKind } from '../../models/vivado-file';
+import { VivadoProject } from '../../models/vivado-project';
+import VivadoProjectManager from '../../vivado-project-manager';
+import { quoteTclString } from '../../utils/vivado-tcl';
+import { vivadoRun, VivadoRunOptions } from '../../utils/vivado-run';
+
+const commandId = 'vscode-vivado.projects.runBehavioralSimulation';
+
+export interface VivadoBehavioralSimulationTarget {
+    project?: VivadoProject;
+    file?: VivadoFile;
+}
+
+export interface ResolvedVivadoBehavioralSimulation {
+    project: VivadoProject;
+    simsetName: string;
+    sourceFile?: VivadoFile;
+}
+
+export interface RunVivadoBehavioralSimulationDependencies {
+    vivadoRun: (startPath: vscode.Uri, tcl: string, taskName: string, options?: VivadoRunOptions) => Promise<number | undefined>;
+    showErrorMessage: (message: string) => Thenable<string | undefined>;
+    showInformationMessage: (message: string) => Thenable<string | undefined>;
+    getTaskExecutions: () => readonly vscode.TaskExecution[];
+    refreshVivadoProjects: () => void | Promise<void>;
+}
+
+export interface RunVivadoBehavioralSimulationOptions {
+    dependencies?: Partial<RunVivadoBehavioralSimulationDependencies>;
+}
+
+export default async function runVivadoBehavioralSimulation(
+    target: VivadoProject | VivadoBehavioralSimulationTarget | undefined,
+    options: RunVivadoBehavioralSimulationOptions = {},
+): Promise<boolean> {
+    const dependencies = resolveDependencies(options.dependencies);
+
+    try {
+        const resolvedTarget = resolveBehavioralSimulationTarget(target);
+        ensureNoActiveVivadoTask(dependencies.getTaskExecutions());
+
+        const taskName = buildVivadoBehavioralSimulationTaskName(resolvedTarget.project, resolvedTarget.simsetName);
+        const exitCode = await dependencies.vivadoRun(
+            resolvedTarget.project.uri,
+            buildVivadoBehavioralSimulationTcl(resolvedTarget),
+            taskName,
+            {
+                presentationOptions: {
+                    reveal: vscode.TaskRevealKind.Always,
+                    panel: vscode.TaskPanelKind.Shared,
+                    clear: false,
+                },
+            },
+        );
+
+        if (exitCode === 0) {
+            await dependencies.showInformationMessage(
+                `Vivado behavioral simulation completed for ${resolvedTarget.project.name}/${resolvedTarget.simsetName}.`,
+            );
+            await dependencies.refreshVivadoProjects();
+            return true;
+        }
+
+        if (exitCode === undefined) {
+            return false;
+        }
+
+        await dependencies.showErrorMessage(
+            `Vivado behavioral simulation failed for ${resolvedTarget.project.name}/${resolvedTarget.simsetName}. ` +
+            'Review the Vivado task output and generated TCL script.',
+        );
+        return false;
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        await dependencies.showErrorMessage(message);
+        return false;
+    }
+}
+
+export function resolveBehavioralSimulationTarget(
+    target: VivadoProject | VivadoBehavioralSimulationTarget | undefined,
+): ResolvedVivadoBehavioralSimulation {
+    if (!target) {
+        throw new Error('Select a Vivado project or simulation source file in the Projects view before running behavioral simulation.');
+    }
+
+    if (target instanceof VivadoProject) {
+        return {
+            project: target,
+            simsetName: chooseDefaultSimulationFileset(target),
+        };
+    }
+
+    if (!(target.project instanceof VivadoProject)) {
+        throw new Error('Select a Vivado project or simulation source file in the Projects view before running behavioral simulation.');
+    }
+
+    if (!target.file) {
+        return {
+            project: target.project,
+            simsetName: chooseDefaultSimulationFileset(target.project),
+        };
+    }
+
+    if (!(target.file instanceof VivadoFile) || target.file.kind !== VivadoFileKind.SimulationSource) {
+        throw new Error('Select a Vivado simulation source file before running behavioral simulation from a file target.');
+    }
+
+    if (!target.file.filesetName) {
+        throw new Error(`Simulation source ${path.basename(target.file.uri.fsPath)} is not associated with a Vivado simulation fileset.`);
+    }
+
+    return {
+        project: target.project,
+        simsetName: target.file.filesetName,
+        sourceFile: target.file,
+    };
+}
+
+export function buildVivadoBehavioralSimulationTcl(target: ResolvedVivadoBehavioralSimulation): string {
+    const projectPath = quoteTclString(target.project.xprFile.fsPath);
+    const simsetName = quoteTclString(target.simsetName);
+    const sourceComment = target.sourceFile
+        ? [`# Selected simulation source: ${target.sourceFile.uri.fsPath}`]
+        : [];
+
+    return [
+        ...sourceComment,
+        `open_project ${projectPath}`,
+        `set simset_name ${simsetName}`,
+        'set simset [get_filesets -quiet $simset_name]',
+        'if {[llength $simset] == 0} {',
+        `    error ${quoteTclString(`Simulation fileset ${target.simsetName} was not found`)}`,
+        '}',
+        'current_fileset -simset $simset',
+        'launch_simulation -simset $simset_name -mode behavioral',
+        'run all',
+        'close_sim',
+        'close_project',
+    ].join('\n');
+}
+
+export function buildVivadoBehavioralSimulationTaskName(project: VivadoProject, simsetName: string): string {
+    return `Vivado: Behavioral Simulation ${project.name}/${simsetName}`;
+}
+
+function chooseDefaultSimulationFileset(project: VivadoProject): string {
+    const simulationFilesets = project.simulationFilesets
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name));
+    const fileset = simulationFilesets.find(candidate => candidate.name === 'sim_1') ?? simulationFilesets[0];
+
+    if (!fileset) {
+        throw new Error(`Vivado project ${project.name} has no simulation filesets.`);
+    }
+
+    return fileset.name;
+}
+
+function ensureNoActiveVivadoTask(taskExecutions: readonly vscode.TaskExecution[]): void {
+    if (taskExecutions.some(execution => execution.task.source === vivadoTaskSource)) {
+        throw new Error('A Vivado task is already running. Wait for it to finish before starting behavioral simulation.');
+    }
+}
+
+function resolveDependencies(
+    dependencies: Partial<RunVivadoBehavioralSimulationDependencies> = {},
+): RunVivadoBehavioralSimulationDependencies {
+    return {
+        vivadoRun,
+        showErrorMessage: message => vscode.window.showErrorMessage(message),
+        showInformationMessage: message => vscode.window.showInformationMessage(message),
+        getTaskExecutions: () => vscode.tasks.taskExecutions,
+        refreshVivadoProjects: () => VivadoProjectManager.instance.refresh(),
+        ...dependencies,
+    };
+}
+
+export { commandId as runVivadoBehavioralSimulationCommandId };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import runCsynth from './commands/project/run/projects-run-csynth';
 import stopCosim from './commands/project/run/projects-stop-cosim';
 import stopCsim from './commands/project/run/projects-stop-csim';
 import stopCsynth from './commands/project/run/projects-stop-csynth';
+import runVivadoBehavioralSimulation, { runVivadoBehavioralSimulationCommandId } from './commands/vivado/run-behavioral-simulation';
 import generateVivadoBitstream, { generateVivadoBitstreamCommandId } from './commands/vivado/generate-bitstream';
 import cleanVivadoRunOutputs, { cleanVivadoRunOutputsCommandId } from './commands/vivado/clean-run-outputs';
 import openVivadoProject, { openVivadoProjectCommandId } from './commands/vivado/open-project';
@@ -18,7 +19,7 @@ import runVivadoSynthesis, { runVivadoSynthesisCommandId } from './commands/viva
 import { OutputConsole } from './output-console';
 import ProjectManager from './project-manager';
 import VivadoProjectManager from './vivado-project-manager';
-import ProjectsViewTreeProvider, { ProjectFileItem, ProjectSourceItem, ProjectTestBenchItem, VivadoProjectTreeItem, VivadoRunTreeItem } from './views/projects-tree';
+import ProjectsViewTreeProvider, { ProjectFileItem, ProjectSourceItem, ProjectTestBenchItem, VivadoProjectFileItem, VivadoProjectTreeItem, VivadoRunTreeItem } from './views/projects-tree';
 
 // TODO Make Vitis Unified IDE optional
 // TODO Proper feedback to let ppl know they don't have Vitis Unified IDE
@@ -55,6 +56,9 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand(runVivadoSynthesisCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => runVivadoSynthesis(e)),
 		vscode.commands.registerCommand(runVivadoImplementationCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => runVivadoImplementation(e)),
 		vscode.commands.registerCommand(generateVivadoBitstreamCommandId, (e?: VivadoProjectTreeItem | VivadoRunTreeItem) => generateVivadoBitstream(e)),
+		vscode.commands.registerCommand(runVivadoBehavioralSimulationCommandId, (e?: VivadoProjectTreeItem | VivadoProjectFileItem) => {
+			return runVivadoBehavioralSimulation(e instanceof VivadoProjectTreeItem ? e.project : e);
+		}),
 		projectsViewProvider,
 		OutputConsole.instance,
 		ProjectManager.instance,

--- a/src/models/vivado-project.ts
+++ b/src/models/vivado-project.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import * as vscode from 'vscode';
 import { VivadoBlockDesign } from './vivado-block-design';
 import { VivadoFile } from './vivado-file';
-import { VivadoFileset } from './vivado-fileset';
+import { VivadoFileset, VivadoFilesetKind } from './vivado-fileset';
 import { VivadoIp } from './vivado-ip';
 import { VivadoReport } from './vivado-report';
 import { VivadoRun, VivadoRunType } from './vivado-run';
@@ -73,6 +73,10 @@ export class VivadoProject {
 
     public get simulationSources(): VivadoFile[] {
         return this.filesets.flatMap(fileset => fileset.simulationSources);
+    }
+
+    public get simulationFilesets(): VivadoFileset[] {
+        return this.filesets.filter(fileset => fileset.kind === VivadoFilesetKind.Simulation);
     }
 
     public get constraints(): VivadoFile[] {

--- a/src/test/commands/vivado-run-behavioral-simulation.test.ts
+++ b/src/test/commands/vivado-run-behavioral-simulation.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for running Vivado behavioral simulation through generated TCL.
+ * Covers #15 - Add behavioral XSim run support.
+ */
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { runVivadoBehavioralSimulationCommandId } from '../../commands/vivado/run-behavioral-simulation';
+import runVivadoBehavioralSimulation, {
+    buildVivadoBehavioralSimulationTaskName,
+    buildVivadoBehavioralSimulationTcl,
+    resolveBehavioralSimulationTarget,
+} from '../../commands/vivado/run-behavioral-simulation';
+import { vivadoTaskSource } from '../../constants';
+import { VivadoFile, VivadoFileKind } from '../../models/vivado-file';
+import { VivadoFileset, VivadoFilesetKind } from '../../models/vivado-fileset';
+import { VivadoProject } from '../../models/vivado-project';
+import { quoteTclString } from '../../utils/vivado-tcl';
+
+function makeProject(filesets: VivadoFileset[] = [makeSimulationFileset('sim_1')]): VivadoProject {
+    return new VivadoProject({
+        name: 'demo',
+        uri: vscode.Uri.file('/workspace/demo'),
+        xprFile: vscode.Uri.file('/workspace/demo/demo.xpr'),
+        filesets,
+    });
+}
+
+function makeSimulationFileset(name: string): VivadoFileset {
+    return new VivadoFileset({
+        name,
+        kind: VivadoFilesetKind.Simulation,
+        files: [
+            makeSimulationFile(name, `${name}_tb.sv`),
+        ],
+    });
+}
+
+function makeSimulationFile(filesetName: string, fileName: string = 'top_tb.sv'): VivadoFile {
+    return new VivadoFile({
+        uri: vscode.Uri.file(`/workspace/demo/sim/${fileName}`),
+        kind: VivadoFileKind.SimulationSource,
+        filesetName,
+    });
+}
+
+function makeDesignFile(): VivadoFile {
+    return new VivadoFile({
+        uri: vscode.Uri.file('/workspace/demo/rtl/top.sv'),
+        kind: VivadoFileKind.DesignSource,
+        filesetName: 'sources_1',
+    });
+}
+
+function makeVivadoTaskExecution(): vscode.TaskExecution {
+    const task = new vscode.Task(
+        { type: 'shell' },
+        vscode.TaskScope.Workspace,
+        'busy',
+        vivadoTaskSource,
+        new vscode.ShellExecution('vivado -mode batch'),
+    );
+
+    return { task } as vscode.TaskExecution;
+}
+
+suite('Vivado behavioral simulation TCL generation', () => {
+    test('builds project-mode TCL for a simulation fileset', () => {
+        const project = makeProject();
+
+        assert.strictEqual(
+            buildVivadoBehavioralSimulationTcl({
+                project,
+                simsetName: 'sim_1',
+            }),
+            [
+                `open_project ${quoteTclString(project.xprFile.fsPath)}`,
+                `set simset_name ${quoteTclString('sim_1')}`,
+                'set simset [get_filesets -quiet $simset_name]',
+                'if {[llength $simset] == 0} {',
+                `    error ${quoteTclString('Simulation fileset sim_1 was not found')}`,
+                '}',
+                'current_fileset -simset $simset',
+                'launch_simulation -simset $simset_name -mode behavioral',
+                'run all',
+                'close_sim',
+                'close_project',
+            ].join('\n'),
+        );
+    });
+
+    test('annotates TCL generated from a selected simulation source', () => {
+        const project = makeProject();
+        const sourceFile = makeSimulationFile('sim_1', 'top_tb.sv');
+
+        assert.ok(
+            buildVivadoBehavioralSimulationTcl({
+                project,
+                simsetName: 'sim_1',
+                sourceFile,
+            }).startsWith(`# Selected simulation source: ${sourceFile.uri.fsPath}\nopen_project`),
+        );
+    });
+
+    test('builds stable task names from the project and simulation fileset', () => {
+        assert.strictEqual(
+            buildVivadoBehavioralSimulationTaskName(makeProject(), 'sim_1'),
+            'Vivado: Behavioral Simulation demo/sim_1',
+        );
+    });
+});
+
+suite('Vivado behavioral simulation target resolution', () => {
+    test('prefers sim_1 for project-level commands', () => {
+        const sim2 = makeSimulationFileset('sim_2');
+        const sim1 = makeSimulationFileset('sim_1');
+        const project = makeProject([sim2, sim1]);
+
+        assert.deepStrictEqual(resolveBehavioralSimulationTarget(project), {
+            project,
+            simsetName: 'sim_1',
+        });
+    });
+
+    test('falls back to the first sorted simulation fileset', () => {
+        const simB = makeSimulationFileset('sim_b');
+        const simA = makeSimulationFileset('sim_a');
+        const project = makeProject([simB, simA]);
+
+        assert.strictEqual(resolveBehavioralSimulationTarget({ project }).simsetName, 'sim_a');
+    });
+
+    test('uses the selected simulation source fileset', () => {
+        const selectedFile = makeSimulationFile('sim_custom');
+        const project = makeProject([new VivadoFileset({
+            name: 'sim_custom',
+            kind: VivadoFilesetKind.Simulation,
+            files: [selectedFile],
+        })]);
+
+        assert.deepStrictEqual(resolveBehavioralSimulationTarget({ project, file: selectedFile }), {
+            project,
+            simsetName: 'sim_custom',
+            sourceFile: selectedFile,
+        });
+    });
+
+    test('rejects projects without simulation filesets', () => {
+        const project = makeProject([]);
+
+        assert.throws(
+            () => resolveBehavioralSimulationTarget(project),
+            /has no simulation filesets/,
+        );
+    });
+
+    test('rejects non-simulation source file targets', () => {
+        const project = makeProject();
+
+        assert.throws(
+            () => resolveBehavioralSimulationTarget({ project, file: makeDesignFile() }),
+            /Select a Vivado simulation source file/,
+        );
+    });
+});
+
+suite('runVivadoBehavioralSimulation', () => {
+    test('runs generated TCL through vivadoRun and refreshes after success', async () => {
+        const project = makeProject();
+        let capturedTcl = '';
+        let capturedTaskName = '';
+        let capturedStartPath: vscode.Uri | undefined;
+        let infoMessage = '';
+        let refreshed = false;
+
+        const result = await runVivadoBehavioralSimulation(project, {
+            dependencies: {
+                vivadoRun: async (startPath, tcl, taskName) => {
+                    capturedStartPath = startPath;
+                    capturedTcl = tcl;
+                    capturedTaskName = taskName;
+                    return 0;
+                },
+                showInformationMessage: async message => {
+                    infoMessage = message;
+                    return undefined;
+                },
+                showErrorMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, true);
+        assert.strictEqual(capturedStartPath?.fsPath, project.uri.fsPath);
+        assert.strictEqual(capturedTaskName, buildVivadoBehavioralSimulationTaskName(project, 'sim_1'));
+        assert.strictEqual(capturedTcl, buildVivadoBehavioralSimulationTcl({ project, simsetName: 'sim_1' }));
+        assert.ok(infoMessage.includes('Vivado behavioral simulation completed'));
+        assert.strictEqual(refreshed, true);
+    });
+
+    test('reports missing simulation filesets without generating TCL', async () => {
+        const project = makeProject([]);
+        let errorMessage = '';
+        let vivadoRunCalled = false;
+
+        const result = await runVivadoBehavioralSimulation(project, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(vivadoRunCalled, false);
+        assert.ok(errorMessage.includes('has no simulation filesets'));
+    });
+
+    test('rejects concurrent Vivado tasks before generating TCL', async () => {
+        const project = makeProject();
+        let errorMessage = '';
+        let vivadoRunCalled = false;
+
+        const result = await runVivadoBehavioralSimulation(project, {
+            dependencies: {
+                vivadoRun: async () => {
+                    vivadoRunCalled = true;
+                    return 0;
+                },
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                getTaskExecutions: () => [makeVivadoTaskExecution()],
+                refreshVivadoProjects: () => { /* no-op */ },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(vivadoRunCalled, false);
+        assert.ok(errorMessage.includes('already running'));
+    });
+
+    test('reports nonzero Vivado exits without refreshing', async () => {
+        const project = makeProject();
+        let errorMessage = '';
+        let refreshed = false;
+
+        const result = await runVivadoBehavioralSimulation(project, {
+            dependencies: {
+                vivadoRun: async () => 1,
+                showErrorMessage: async message => {
+                    errorMessage = message;
+                    return undefined;
+                },
+                showInformationMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.ok(errorMessage.includes('Vivado behavioral simulation failed'));
+        assert.strictEqual(refreshed, false);
+    });
+
+    test('treats undefined Vivado exits as canceled without refreshing', async () => {
+        const project = makeProject();
+        let refreshed = false;
+
+        const result = await runVivadoBehavioralSimulation(project, {
+            dependencies: {
+                vivadoRun: async () => undefined,
+                showErrorMessage: async () => undefined,
+                showInformationMessage: async () => undefined,
+                getTaskExecutions: () => [],
+                refreshVivadoProjects: () => {
+                    refreshed = true;
+                },
+            },
+        });
+
+        assert.strictEqual(result, false);
+        assert.strictEqual(refreshed, false);
+    });
+});
+
+suite('Vivado behavioral simulation package contribution', () => {
+    test('contributes Run Behavioral Simulation to project and simulation source file items', () => {
+        const pkg = require('../../../package.json');
+        const command = pkg.contributes.commands.find((entry: { command: string }) => entry.command === runVivadoBehavioralSimulationCommandId);
+        const paletteEntry = pkg.contributes.menus.commandPalette.find((entry: { command: string }) => entry.command === runVivadoBehavioralSimulationCommandId);
+        const contextEntries = pkg.contributes.menus['view/item/context'].filter((entry: { command: string }) => entry.command === runVivadoBehavioralSimulationCommandId);
+
+        assert.strictEqual(command.title, 'Run Behavioral Simulation');
+        assert.strictEqual(paletteEntry.when, 'false');
+        assert.deepStrictEqual(
+            contextEntries.map((entry: { when: string }) => entry.when).sort(),
+            [
+                'view == projectsView && viewItem == vivadoProjectItem',
+                'view == projectsView && viewItem == vivadoSimulationSourceFileItem',
+            ],
+        );
+    });
+});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -10,6 +10,7 @@ import { generateVivadoBitstreamCommandId } from '../commands/vivado/generate-bi
 import { openVivadoProjectCommandId } from '../commands/vivado/open-project';
 import { previewVivadoGeneratedTclCommandId } from '../commands/vivado/preview-generated-tcl';
 import { resetVivadoRunCommandId } from '../commands/vivado/reset-run';
+import { runVivadoBehavioralSimulationCommandId } from '../commands/vivado/run-behavioral-simulation';
 import { runVivadoImplementationCommandId } from '../commands/vivado/run-implementation';
 import { runVivadoSynthesisCommandId } from '../commands/vivado/run-synthesis';
 
@@ -141,6 +142,7 @@ suite('Extension activation', () => {
         assert.ok(registeredCommands.includes(runVivadoSynthesisCommandId));
         assert.ok(registeredCommands.includes(runVivadoImplementationCommandId));
         assert.ok(registeredCommands.includes(generateVivadoBitstreamCommandId));
+        assert.ok(registeredCommands.includes(runVivadoBehavioralSimulationCommandId));
     });
 });
 

--- a/src/test/models/vivado-project.test.ts
+++ b/src/test/models/vivado-project.test.ts
@@ -140,6 +140,7 @@ suite('VivadoProject', () => {
 
         assert.deepStrictEqual(project.designSources.map(file => path.basename(file.uri.fsPath)), ['top.sv']);
         assert.deepStrictEqual(project.simulationSources.map(file => path.basename(file.uri.fsPath)), ['top_tb.sv']);
+        assert.deepStrictEqual(project.simulationFilesets.map(fileset => fileset.name), ['sim_1']);
         assert.deepStrictEqual(project.constraints.map(file => path.basename(file.uri.fsPath)), ['top.xdc']);
         assert.strictEqual(project.files.length, 3);
     });

--- a/src/test/views/projects-tree.test.ts
+++ b/src/test/views/projects-tree.test.ts
@@ -350,6 +350,7 @@ suite('ProjectsViewTreeProvider', () => {
         const files = await (designSources as TestTreeNode<VivadoProjectFileItem[]>).getChildren();
 
         assert.deepStrictEqual(files.map(file => file.label), ['a.sv', 'z.sv']);
+        assert.strictEqual(files[0].project, vivadoProjectsProvider.projects[0]);
         assert.strictEqual(files[0].contextValue, 'vivadoDesignSourceFileItem');
         assert.strictEqual(files[0].command?.command, 'vscode.open');
     });

--- a/src/views/projects-tree.ts
+++ b/src/views/projects-tree.ts
@@ -97,6 +97,7 @@ export class VivadoProjectTreeItem extends TreeItem {
             'vivadoDesignSourcesItem',
             'file-code',
             'vivadoDesignSourceFileItem',
+            () => this.project,
             () => this.project.designSources,
         );
         this._simulationSourcesItem = new VivadoFileCategoryItem(
@@ -104,6 +105,7 @@ export class VivadoProjectTreeItem extends TreeItem {
             'vivadoSimulationSourcesItem',
             'beaker',
             'vivadoSimulationSourceFileItem',
+            () => this.project,
             () => this.project.simulationSources,
         );
         this._constraintsItem = new VivadoFileCategoryItem(
@@ -111,6 +113,7 @@ export class VivadoProjectTreeItem extends TreeItem {
             'vivadoConstraintsItem',
             'symbol-ruler',
             'vivadoConstraintFileItem',
+            () => this.project,
             () => this.project.constraints,
         );
         this._runsItem = new VivadoRunsItem(() => this.project, () => this.project.runs);
@@ -139,6 +142,7 @@ export class VivadoProjectTreeItem extends TreeItem {
 }
 
 class VivadoFileCategoryItem extends TreeItem {
+    private readonly _getProject: () => VivadoProject;
     private readonly _getFiles: () => VivadoFile[];
     private readonly _fileContextValue: string;
 
@@ -147,11 +151,13 @@ class VivadoFileCategoryItem extends TreeItem {
         contextValue: string,
         iconId: string,
         fileContextValue: string,
+        getProject: () => VivadoProject,
         getFiles: () => VivadoFile[],
     ) {
         super(label, vscode.TreeItemCollapsibleState.Collapsed);
         this.contextValue = contextValue;
         this.iconPath = new vscode.ThemeIcon(iconId);
+        this._getProject = getProject;
         this._getFiles = getFiles;
         this._fileContextValue = fileContextValue;
     }
@@ -160,15 +166,17 @@ class VivadoFileCategoryItem extends TreeItem {
         return Promise.resolve(this._getFiles()
             .slice()
             .sort((a, b) => path.basename(a.uri.fsPath).localeCompare(path.basename(b.uri.fsPath)))
-            .map(file => new VivadoProjectFileItem(file, this._fileContextValue)));
+            .map(file => new VivadoProjectFileItem(this._getProject(), file, this._fileContextValue)));
     }
 }
 
 export class VivadoProjectFileItem extends TreeItem {
+    public readonly project: VivadoProject;
     public readonly file: VivadoFile;
 
-    constructor(file: VivadoFile, contextValue: string) {
+    constructor(project: VivadoProject, file: VivadoFile, contextValue: string) {
         super(path.basename(file.uri.fsPath));
+        this.project = project;
         this.file = file;
         this.contextValue = contextValue;
         this.resourceUri = file.uri;


### PR DESCRIPTION
## Summary
- add a `Run Behavioral Simulation` command for Vivado projects and simulation source files
- generate project-mode XSim TCL with `launch_simulation -mode behavioral` and `run all`
- route simulation runs through the existing Vivado task helper for visible, cancellable output
- track project ownership on Vivado file tree items so selected simulation sources can resolve their fileset
- document current project-mode XSim support and leave standalone/post-synthesis simulation as future work

Closes #15

## Validation
- npm run compile
- npm run lint
- npm test
- make PYTHON=C:/Users/cosgroma/.pyenv/pyenv-win/versions/3.11.9/python.exe docs
- git diff --check